### PR TITLE
Generator voor statische webpagina's toegevoegd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 node_modules
 dist
 public/generated
+public/over-ons
+public/videos
+public/v
+public/htmlHeadTags.html
 
 
 # local env files

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build"
+    "precompile": "sh update/precompile.sh",
+    "compile": "vue-cli-service build",
+    "postcompile": "python update/postcompile.py"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.1.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",
-    "precompile": "sh update/precompile.sh",
     "compile": "vue-cli-service build",
     "postcompile": "python update/postcompile.py"
   },

--- a/public/404.html
+++ b/public/404.html
@@ -1,8 +1,19 @@
 <!DOCTYPE html>
-<html>
+<html lang="nl">
   <head>
+    <!-- General Meta Tags -->
     <meta charset="utf-8">
-    <title>Omleiden...</title>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <!-- Primary Meta Tags -->
+    <title>Omleiden... - OINC</title>
+    <meta name="title" content="OINC">
+    <meta name="description" content="OINC is een werkgroep van het Onze-Lieve-Vrouwecollege Assebroek. Wij staan in voor het filmen en monteren van activiteiten in en rond de school en brengen zo het leven in OLVA in beeld.">
+    <meta name="keywords" content="OINC, OINCtvvanolva, OLVA, Onze-Lieve-Vrouwecollege, Assebroek, filmen, monteren">
+    <meta name="author" content="Onze-Lieve-Vrouwecollege Assebroek">
+    <!-- Favicon -->
+    <link rel="icon" href="favicon.ico">
+    <!-- Redirect Script -->
     <script type="text/javascript">
       // Single Page Apps for GitHub Pages
       // MIT License
@@ -34,14 +45,14 @@
       );
     </script>
   </head>
-  <body>
+  <body style="background-color: black; overflow-x: hidden;">
     <noscript>
-      <iframe src="/enablejs.html" frameborder="0" style="width: 100vw; height: 100vh;"></iframe>
+      <iframe src="/enablejs.html" frameborder="0" style="width: 100%; height: 100vh"></iframe>
       <style>
         body {
           margin: 0;
           padding: 0;
-          overflow-y: hidden;
+          min-height: 100vh;
         }
       </style>
     </noscript>

--- a/public/404.html
+++ b/public/404.html
@@ -35,5 +35,15 @@
     </script>
   </head>
   <body>
+    <noscript>
+      <iframe src="/enablejs.html" frameborder="0" style="width: 100vw; height: 100vh;"></iframe>
+      <style>
+        body {
+          margin: 0;
+          padding: 0;
+          overflow-y: hidden;
+        }
+      </style>
+    </noscript>
   </body>
 </html>

--- a/public/enablejs.html
+++ b/public/enablejs.html
@@ -1,10 +1,18 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="nl">
 <head>
-    <meta charset="UTF-8">
+    <!-- General Meta Tags -->
+    <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Schakel JavaScript in</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <!-- Primary Meta Tags -->
+    <title>Schakel JavaScript in - OINC</title>
+    <meta name="title" content="OINC">
+    <meta name="description" content="OINC is een werkgroep van het Onze-Lieve-Vrouwecollege Assebroek. Wij staan in voor het filmen en monteren van activiteiten in en rond de school en brengen zo het leven in OLVA in beeld.">
+    <meta name="keywords" content="OINC, OINCtvvanolva, OLVA, Onze-Lieve-Vrouwecollege, Assebroek, filmen, monteren">
+    <meta name="author" content="Onze-Lieve-Vrouwecollege Assebroek">
+    <!-- Favicon -->
+    <link rel="icon" href="favicon.ico">
 </head>
 <body>
     <img src="/logo.svg" alt="OINC">

--- a/public/enablejs.html
+++ b/public/enablejs.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Schakel JavaScript in</title>
+</head>
+<body>
+    <img src="/logo.svg" alt="OINC">
+
+    <main id="info">
+      Gelieve JavaScript in te schakelen om het beste uit deze website te halen<br>
+      <form>
+        <button type="submit">Deze pagina herladen</button>
+      </form><br><br>
+
+      <details>
+        <summary>Klik hier voor meer informatie over OINC</summary>
+        <iframe src="/generated/links.html" frameborder="0" width="400" height="300" title="Korte info over het OINC kanaal"></iframe>
+      </details>
+    </main>
+
+    <footer class="footer">
+      © OINC is een werkgroep van het Onze-Lieve-Vrouwecollege Assebroek (Brugge). <a href="https://olva.be/">olva.be</a> <a href="https://olva.be/privacy/">Privacy / disclaimer</a>
+    </footer>
+
+    <style>
+        body {
+            background-color: black;
+        }
+        img {
+            height: 50px;
+            margin: 40px;
+        }
+        #info {
+            position: absolute;
+            top: 50%;
+            width: 99%;
+            color: white;
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            text-align: center;
+        }
+        form {
+            margin: 20px 0;
+        }
+        a, summary {
+            margin: 0 5px;
+            color: lightblue;
+            border: 2px solid transparent;
+        }
+        #links {
+            display: none;
+            height: 100px;
+            background: rgb(70, 70, 70);
+            margin: 20px 60px;
+            border: 1px solid gray;
+        }
+        footer {
+            position: fixed;
+            box-sizing: border-box;
+            bottom: 0;
+            left: 0;
+            width: 100%;
+            background-color: rgb(40, 40, 40);
+            color: white;
+            padding: 10px;
+        }
+        iframe {
+            margin-top: 10px;
+            margin-bottom: 80px;
+            border: 1px solid rgb(75, 75, 75);
+        }
+        :focus, :target {
+            outline: 2px solid #55c7e4;
+        }
+    </style>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -12,66 +12,12 @@
   </head>
   <body style="background-color: black; overflow-x: hidden;">
     <noscript>
-      <img src="/logo.svg" alt="OINC">
-      <main id="info">
-        Gelieve JavaScript in te schakelen om het beste uit deze website te halen<br>
-        <form>
-          <button type="submit">Deze pagina herladen</button>
-        </form><br><br>
-
-        <details>
-          <summary>Klik hier voor meer informatie over OINC</summary>
-          <iframe src="/generated/links.html" frameborder="0" width="400" height="300" title="Korte info over het OINC kanaal"></iframe>
-        </details>
-      </main>
-      <footer class="footer">
-        © OINC is een werkgroep van het Onze-Lieve-Vrouwecollege Assebroek (Brugge). <a href="https://olva.be/">olva.be</a> <a href="https://olva.be/privacy/">Privacy / disclaimer</a>
-      </footer>
+      <iframe src="/enablejs.html" frameborder="0" style="width: 100vw; height: 100vh;"></iframe>
       <style>
-        img {
-          height: 50px;
-          margin: 40px;
-        }
-        #info {
-          position: absolute;
-          top: 50%;
-          width: 99%;
-          color: white;
-          font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-          text-align: center;
-        }
-        form {
-          margin: 20px 0;
-        }
-        a, summary {
-          margin: 0 5px;
-          color: lightblue;
-          border: 2px solid transparent;
-        }
-        #links {
-          display: none;
-          height: 100px;
-          background: rgb(70, 70, 70);
-          margin: 20px 60px;
-          border: 1px solid gray;
-        }
-        footer {
-          position: fixed;
-          box-sizing: border-box;
-          bottom: 0;
-          left: 0;
-          width: 100%;
-          background-color: rgb(40, 40, 40);
-          color: white;
-          padding: 10px;
-        }
-        iframe {
-          margin-top: 10px;
-          margin-bottom: 80px;
-          border: 1px solid rgb(75, 75, 75);
-        }
-        :focus, :target {
-          border: 2px dotted white;
+        body {
+          margin: 0;
+          padding: 0;
+          overflow-y: hidden;
         }
       </style>
     </noscript>

--- a/public/index.html
+++ b/public/index.html
@@ -14,7 +14,6 @@
     <!-- Favicon -->
     <link rel="icon" href="favicon.ico">
     <!-- Content scripts and styles -->
-    $headTags
   </head>
   <body style="background-color: black; overflow-x: hidden;">
     <noscript>

--- a/public/index.html
+++ b/public/index.html
@@ -1,23 +1,29 @@
 <!DOCTYPE html>
-<html lang="">
+<html lang="nl">
   <head>
+    <!-- General Meta Tags -->
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <!-- Primary Meta Tags -->
+    <title>OINC</title>
+    <meta name="title" content="OINC">
     <meta name="description" content="OINC is een werkgroep van het Onze-Lieve-Vrouwecollege Assebroek. Wij staan in voor het filmen en monteren van activiteiten in en rond de school en brengen zo het leven in OLVA in beeld.">
     <meta name="keywords" content="OINC, OINCtvvanolva, OLVA, Onze-Lieve-Vrouwecollege, Assebroek, filmen, monteren">
     <meta name="author" content="Onze-Lieve-Vrouwecollege Assebroek">
-    <meta name="viewport" content="width=device-width,initial-scale=1.0">
-    <link rel="icon" href="<%= BASE_URL %>favicon.ico">
-    <title>OINC</title>
+    <!-- Favicon -->
+    <link rel="icon" href="favicon.ico">
+    <!-- Content scripts and styles -->
+    $headTags
   </head>
   <body style="background-color: black; overflow-x: hidden;">
     <noscript>
-      <iframe src="/enablejs.html" frameborder="0" style="width: 100vw; height: 100vh;"></iframe>
+      <iframe src="/enablejs.html" frameborder="0" style="width: 100%; height: 100vh"></iframe>
       <style>
         body {
           margin: 0;
           padding: 0;
-          overflow-y: hidden;
+          min-height: 100vh;
         }
       </style>
     </noscript>

--- a/update/build.py
+++ b/update/build.py
@@ -739,7 +739,7 @@ def main(env):
                 html = html.replace('$headTags', html_head_tags)
 
             # Sla bestand op
-            saveLocalText(f"{pathRel}/{rel_dir}/index.html", html)
+            saveLocalText(f"{pathRel}/{rel_dir}/index{'.html.template' if pathRel == '../public' else '.html'}", html)
             logSave(f"index.html ({page_rel_url})", os.path.abspath(f"{pathRel}/{rel_dir}/index.html"))
 
     print("Saving general data...")

--- a/update/build.py
+++ b/update/build.py
@@ -562,7 +562,7 @@ def main(env):
     links_html = f"<!DOCTYPE html>\n<html>\n<head>\n<title>Korte info over oinc</title>\n</head>\n<body>\n<li>Ons kanaal: <a href=\"https://youtube.com/channel/{ENV_VARS['youtube_channel_id']}\" target=\"_blank\" aria-label=\"Ons kanaal\">klik</a></li>\n"
     for link in social_links:
         links_html += f"<li>{link['name']}: <a href=\"{link['url']}\" target=\"_blank\" aria-label=\"{link['name']}\">klik</a></li>\n"
-    links_html += f"<br>\n<p style=\"white-space: pre-wrap;\">\n{channel_data['description']}\n</p>\n<style>\nbody{{background: black; color: lightgray;}}\na{{color: lightblue; border: 2px solid transparent;}}\n:focus,:target{{border: 2px dotted white;}}\np{{color: rgb(191, 250, 114);}}\n</style>\n</body>\n</html>"
+    links_html += f"<br>\n<p style=\"white-space: pre-wrap;\">\n{channel_data['description']}\n</p>\n<style>\nbody{{background: black; color: lightgray;}}\na{{color: lightblue; border: 2px solid transparent;}}\n:focus,:target{{outline: 2px solid #55c7e4;}}\np{{color: rgb(191, 250, 114);}}\n</style>\n</body>\n</html>"
     print("Generated links.html")
 
     # --- Genereer sitemap -------------------------------------------------------

--- a/update/build.py
+++ b/update/build.py
@@ -565,6 +565,65 @@ def main(env):
     links_html += f"<br>\n<p style=\"white-space: pre-wrap;\">\n{channel_data['description']}\n</p>\n<style>\nbody{{background: black; color: lightgray;}}\na{{color: lightblue; border: 2px solid transparent;}}\n:focus,:target{{outline: 2px solid #55c7e4;}}\np{{color: rgb(191, 250, 114);}}\n</style>\n</body>\n</html>"
     print("Generated links.html")
 
+    # --- Genereer statische pagina's voor SEO: ALGEMEEN (SETUP) -------------------------------------------------------
+    static_html_pages_params = dict()
+    if env == 'dev':
+        with open('static_page_preset.html', 'r') as f:
+            static_html_page_preset = f.read()
+    else:
+        static_html_page_preset_request = urllib.request.urlopen('https://raw.githubusercontent.com/oinc-olva/oinc-olva.github.io/main/update/static_page_preset.html')
+        static_html_page_preset = static_html_page_preset_request.read()
+
+    if env == 'dev':
+        with open(os.path.abspath('../dist/htmlHeadTags.html'), 'r') as f:
+            html_head_tags = f.read()
+    else:
+        with open('htmlHeadTags.html', 'r') as f:
+            html_head_tags = f.read()
+
+    # --- Genereer statische pagina's voor SEO: /over-ons -------------------------------------------------------
+    static_html_pages_params['/over-ons'] = {
+        'title': 'Over ons',
+        'description': "Kom meer te weten over OINC!",
+        'url': f"{ENV_VARS['site_base_url']}/over-ons",
+        'image': f"{ENV_VARS['site_base_url']}/public/generated/img/web/overons.webp",
+        'contentHTML': f"<h2>Over ons</h2><p id=\"preview-description\">{channel_data['description']}</p>"
+    }
+    # --- Genereer statische pagina's voor SEO: /videos -------------------------------------------------------
+    # - Genereer HTML voor afspeellijsten -
+    videos_playlists_html = ""
+    for playlist in channel_data['playlists']:
+        videos_playlists_html += f"<li><a href=\"{ENV_VARS['site_base_url']}/videos/{playlist['videoIds'][0]}/{video_paths[playlist['videoIds'][0]]['path']}?lijst={playlist['id']}\"><h3>{playlist['title']}</h3></a><p class=\"preview-playlists-description\">{playlist['description']}</p></li>"
+
+    # - Genereer HTML voor video's -
+    videos_videos_html = ""
+    for school_year in channel_data['schoolYears']['order']:
+        videos_videos_html += f"<li><h3>{school_year}</h3><ul>"
+        for video_id in channel_data['schoolYears']['values'][school_year]:
+            videos_videos_html += f"<li><a href=\"{ENV_VARS['site_base_url']}/videos/{video_id}/{video_paths[video_id]['path']}\"><h4>{channel_data['videos']['values'][video_id]['title']}</h4></a></li>"
+        videos_videos_html += "</ul></li>"
+
+    # - Sla variabelen op -
+    static_html_pages_params['/videos'] = {
+        'title': 'Video\'s',
+        'description': "Bekijk onze gallerij aan video's!",
+        'url': f"{ENV_VARS['site_base_url']}/videos",
+        'image': f"{ENV_VARS['site_base_url']}/public/generated/img/web/banner_youtube.webp",
+        'contentHTML': f"<h2>Afspeellijsten</h2><ul id=\"preview-playlists\">{videos_playlists_html}</ul><h2>Video's</h2><ul id=\"preview-videos\">{videos_videos_html}</ul>",
+        'styling': "#contentPreview a{display:inline-block}#contentPreview p,#contentPreview h4{margin:0}"
+    }
+    # --- Genereer statische pagina's voor SEO: /videos/:videoid/:videoPath, /v/:videoId -------------------------------------------------------
+    for video_id, video_data in channel_data['videos']['values'].items():
+        video_static_html_page_param = {
+            'title': video_data['title'].replace('\\', '\\\\'),
+            'description': video_data['description'].replace('\\', '\\\\').replace('\n', ' '),
+            'url': f"{ENV_VARS['site_base_url']}/videos/{video_id}/{video_data['videoPath']}",
+            'image': video_data['thumbmaxres'],
+            'contentHTML': f"<p id=\"preview-description\">{video_data['description']}</p><p id=\"preview-info\">{video_data['views']} weergaven | {video_data['publishDate']}</p><p id=\"preview-videoLink\">Link naar video: <a href=\"https://youtube.com/watch?v={video_id}\">https://youtube.com/watch?v={video_id}</a></p><a href=\"{ENV_VARS['site_base_url']}/videos\" id=\"preview-videos-link\">Bekijk onze videogallerij!</a>"
+        }
+        static_html_pages_params[f"/videos/{video_id}/{video_data['videoPath']}"] = video_static_html_page_param
+        static_html_pages_params[f"/v/{video_id}"] = video_static_html_page_param
+
     # --- Genereer sitemap -------------------------------------------------------
     print("Generating sitemap...")
     # Functie om URL van site om te vormen naar bruikbare URL
@@ -634,6 +693,30 @@ def main(env):
 
     def logSave(title, path):
         print(f"  Saved {title} to {path}")
+
+    # Sla alle gegenereerde HTML-pagina's op
+    def saveGeneratedHTMLPages(pathRel, isSubstituteHeadTags):
+        for page_rel_url, page_params in static_html_pages_params.items():
+            # Genereer bestandstructuur
+            rel_dir = ""
+            for sub_dir in page_rel_url.split('/')[1:]:
+                rel_dir += f"/{sub_dir}"
+                if pathRel == '' and rel_dir[0] == '/': rel_dir = rel_dir[1:] # Indien in root en het relatieve mappad begint met een '/', verwijder die
+                createDirIfNotExists(f"{pathRel}/{rel_dir}")
+
+            # Maak HTML
+            html = static_html_page_preset.replace('$title', f"{page_params['title']} - OINC").replace('$description', page_params['description']).replace('$url', page_params['url']).replace('$image', page_params['image']).replace('$contentHTML', page_params['contentHTML'])
+            if 'styling' in page_params:
+                html = html.replace('$styling', f"<style>{page_params['styling']}</style>")
+            else:
+                html = html.replace('$styling', '')
+
+            if isSubstituteHeadTags:
+                html = html.replace('$headTags', html_head_tags)
+
+            # Sla bestand op
+            saveLocalText(f"{pathRel}/{rel_dir}/index.html", html)
+            logSave(f"index.html ({page_rel_url})", os.path.abspath(f"{pathRel}/{rel_dir}/index.html"))
 
     print("Saving general data...")
     if env == 'dev':
@@ -709,6 +792,12 @@ def main(env):
                 convertJPGAndSaveAsWEBP(url, f"../public/generated/img/instagram/{media_file}")
                 if os.path.isdir(os.path.abspath('../dist')):
                     convertJPGAndSaveAsWEBP(url, f"../dist/generated/img/instagram/{media_file}")
+        
+        # Sla gegenereerde HTML-bestanden op
+        print("Saving generated HTML pages...")
+        saveGeneratedHTMLPages('../public', False)
+        if os.path.isdir(os.path.abspath('../dist')):
+            saveGeneratedHTMLPages('../dist', True)
 
     else:
         print("  - Saving to root folder -")
@@ -754,6 +843,10 @@ def main(env):
         else:
             for media_file, url in instagram_image_urls.items():
                 convertJPGAndSaveAsWEBP(url, f"generated/img/instagram/{media_file}")
+
+        # Sla gegenereerde HTML-bestanden op
+        print("Saving generated HTML pages...")
+        saveGeneratedHTMLPages('', True)
 
     print(f"Done! ({instagram_requests_left} instagram requests left)")
 

--- a/update/build.py
+++ b/update/build.py
@@ -581,6 +581,30 @@ def main(env):
         with open('htmlHeadTags.html', 'r') as f:
             html_head_tags = f.read()
 
+    # Genereer content header
+    html_header = "<h2>Pagina's:</h2><ul>"
+    pages = [
+        {
+            'title': 'Home',
+            'path': '/'
+        },
+        {
+            'title': 'Video\'s',
+            'path': '/videos'
+        },
+        {
+            'title': 'Over ons',
+            'path': '/over-ons'
+        }
+    ]
+    for page in pages:
+        html_header += f"<li><a href=\"{page['path']}\">{page['title']}</a></li>"
+
+    html_header += "</ul><h2>Uitgaande links:</h2><ul>"
+    for social_link in channel_data['socialLinks']:
+        html_header += f"<li><a href=\"{social_link['url']}\">{social_link['title']}</a></li>"
+    html_header += "</ul><style>#headerPreview h2,#headerPreview li{color:white}#headerPreview ul{margin-left:30px}</style>"
+
     # --- Genereer statische pagina's voor SEO: /over-ons -------------------------------------------------------
     static_html_pages_params['/over-ons'] = {
         'title': 'Over ons',
@@ -705,7 +729,7 @@ def main(env):
                 createDirIfNotExists(f"{pathRel}/{rel_dir}")
 
             # Maak HTML
-            html = static_html_page_preset.replace('$title', f"{page_params['title']} - OINC").replace('$description', page_params['description']).replace('$url', page_params['url']).replace('$image', page_params['image']).replace('$contentHTML', page_params['contentHTML'])
+            html = static_html_page_preset.replace('$title', f"{page_params['title']} - OINC").replace('$description', page_params['description']).replace('$url', page_params['url']).replace('$image', page_params['image']).replace('$headerHTML', html_header).replace('$contentHTML', page_params['contentHTML'])
             if 'styling' in page_params:
                 html = html.replace('$styling', f"<style>{page_params['styling']}</style>")
             else:

--- a/update/postcompile.py
+++ b/update/postcompile.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+import os
+import glob
+
+def main():
+    # Kopieer gegenereerde head tags
+    with open(os.path.abspath('dist/index.html'), 'r') as f:
+        html_head_tags = f.read()[6:-7]
+    
+    # Sla op in ander bestand
+    f = open(os.path.abspath('dist/htmlHeadTags.html'), "w+")
+    f.write(html_head_tags)
+    f.close()
+    print('Found and saved HTML head tags')
+
+    # Kopieer index.html van /public naar /dist
+    with open(os.path.abspath('public/index.html'), 'r') as src:
+        dest = open(os.path.abspath('dist/index.html'), "w+")
+        dest.write(src.read().replace('$headTags', html_head_tags))
+        dest.close()
+    print('Copied public/index.html --> dist/index.html and (possibly) injected head tags')
+    
+    # Update (bijna) alle html-bestanden in /dist
+    html_files = glob.glob('dist/[!generated]*/**/*.html', recursive=True)
+    for file_ in html_files:
+        html_file_abs = os.path.abspath(file_)
+
+        f = open(html_file_abs, 'r')
+        src = f.read().replace('$headTags', html_head_tags)
+        f.close()
+
+        f = open(html_file_abs, 'w+')
+        f.write(src.replace('$headTags', html_head_tags))
+        f.close()
+    print(f"Injected HTML head tags in (at most) {len(html_files)} files")
+
+    # Verwijder public/htmlHeadTags.html
+    os.remove(os.path.abspath('public/htmlHeadTags.html'))
+            
+
+if __name__ == "__main__":
+    main()

--- a/update/postcompile.py
+++ b/update/postcompile.py
@@ -1,24 +1,18 @@
 #!/usr/bin/env python3
 import os
+import re
 import glob
 
 def main():
     # Kopieer gegenereerde head tags
     with open(os.path.abspath('dist/index.html'), 'r') as f:
-        html_head_tags = f.read()[6:-7]
+        html_head_tags = re.findall(r"\.ico\"\>(.*?)\<\/head\>", f.read())[0]
     
     # Sla op in ander bestand
     f = open(os.path.abspath('dist/htmlHeadTags.html'), "w+")
     f.write(html_head_tags)
     f.close()
     print('Found and saved HTML head tags')
-
-    # Kopieer index.html van /public naar /dist
-    with open(os.path.abspath('public/index.html'), 'r') as src:
-        dest = open(os.path.abspath('dist/index.html'), "w+")
-        dest.write(src.read().replace('$headTags', html_head_tags))
-        dest.close()
-    print('Copied public/index.html --> dist/index.html and (possibly) injected head tags')
     
     # Update (bijna) alle html-bestanden in /dist
     html_files = glob.glob('dist/[!generated]*/**/*.html', recursive=True)
@@ -33,9 +27,6 @@ def main():
         f.write(src.replace('$headTags', html_head_tags))
         f.close()
     print(f"Injected HTML head tags in (at most) {len(html_files)} files")
-
-    # Verwijder public/htmlHeadTags.html
-    os.remove(os.path.abspath('public/htmlHeadTags.html'))
             
 
 if __name__ == "__main__":

--- a/update/postcompile.py
+++ b/update/postcompile.py
@@ -15,15 +15,16 @@ def main():
     print('Found and saved HTML head tags')
     
     # Update (bijna) alle html-bestanden in /dist
-    html_files = glob.glob('dist/[!generated]*/**/*.html', recursive=True)
+    html_files = glob.glob('dist/[!generated]*/**/*.html.template', recursive=True)
     for file_ in html_files:
         html_file_abs = os.path.abspath(file_)
 
         f = open(html_file_abs, 'r')
         src = f.read().replace('$headTags', html_head_tags)
         f.close()
+        os.remove(html_file_abs)
 
-        f = open(html_file_abs, 'w+')
+        f = open(html_file_abs[:-9], 'w+')
         f.write(src.replace('$headTags', html_head_tags))
         f.close()
     print(f"Injected HTML head tags in (at most) {len(html_files)} files")

--- a/update/precompile.sh
+++ b/update/precompile.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-echo "<head></head>" > public/htmlHeadTags.html

--- a/update/precompile.sh
+++ b/update/precompile.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "<head></head>" > public/htmlHeadTags.html

--- a/update/static_page_preset.html
+++ b/update/static_page_preset.html
@@ -33,6 +33,9 @@
 <body style="background-color: black; overflow-x: hidden;">
     <noscript>
       <iframe src="/enablejs.html" frameborder="0" style="width: 100%; height: 100vh"></iframe>
+      <div id="headerPreview">
+        $headerHTML
+      </div>
       <div id="contentPreview" style="color: white; padding: 10px;">
           $contentHTML
       </div>

--- a/update/static_page_preset.html
+++ b/update/static_page_preset.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <!-- General Meta Tags -->
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Primary Meta Tags -->
+  <title>$title</title>
+  <meta name="title" content="$title">
+  <meta name="description" content="$description">
+  <meta name="keywords" content="OINC, OINCtvvanolva, OLVA, Onze-Lieve-Vrouwecollege, Assebroek, filmen, monteren">
+  <meta name="author" content="Onze-Lieve-Vrouwecollege Assebroek">
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="$url">
+  <meta property="og:title" content="$title">
+  <meta property="og:description" content="$description">
+  <meta property="og:image" content="$image">
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:url" content="$url">
+  <meta name="twitter:title" content="$title">
+  <meta name="twitter:description" content="$description">
+  <meta name="twitter:image" content="$image">
+  <!-- Favicon -->
+  <link rel="icon" href="/favicon.ico">
+  <!-- Default styles -->
+  $styling
+  <!-- Content scripts and styles -->
+  $headTags
+</head>
+<body style="background-color: black; overflow-x: hidden;">
+    <noscript>
+      <iframe src="/enablejs.html" frameborder="0" style="width: 100%; height: 100vh"></iframe>
+      <div id="contentPreview" style="color: white; padding: 10px;">
+          $contentHTML
+      </div>
+      <style>
+        body {
+          margin: 0;
+          padding: 0;
+          min-height: 100vh;
+        }
+      </style>
+    </noscript>
+    <div id="app"></div>
+</body>
+</html>

--- a/vue.config.js
+++ b/vue.config.js
@@ -11,11 +11,6 @@ module.exports = {
         }
     },
     chainWebpack: config => {
-        config.plugin('html')
-            .tap(args => {
-                args[0].template = path.resolve(__dirname, 'public/htmlHeadTags.html')
-                return args
-            });
         config.plugin('copy')
             .tap(args => {
                 args[0].patterns[0].globOptions.ignore.push( path.resolve(__dirname, 'public/htmlHeadTags.html').replace(/\\/g, '/') );

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 module.exports = {
     css: {
         loaderOptions: {
@@ -7,5 +9,17 @@ module.exports = {
                 `
             }
         }
+    },
+    chainWebpack: config => {
+        config.plugin('html')
+            .tap(args => {
+                args[0].template = path.resolve(__dirname, 'public/htmlHeadTags.html')
+                return args
+            });
+        config.plugin('copy')
+            .tap(args => {
+                args[0].patterns[0].globOptions.ignore.push( path.resolve(__dirname, 'public/htmlHeadTags.html').replace(/\\/g, '/') );
+                return args;
+            });
     }
 }


### PR DESCRIPTION
Er zijn meerdere voordelen verbonden met statische webpagina's:
- Betere SEO (zoekmachine's vinden de website beter)
- Een deel van de inhoud is nu ook toegankelijk zonder JavaScript
- Sociale media kunnen nu gebruik maken van extra meta-tags, d.w.z. dat de website nu beter kan worden weergegeven in sociale media posts
- Minder doorverbindingen nodig: dit helpt met het proper houden van de browsergeschiedenis en het vermijden van pop-ups in onder andere de Brave-browser.

Deze aanpassingen maken het ontwikkelen van de site iets ingewikkelder, maar ik geloof dat de voordelen de nadelen overstemmen.