### PR TITLE
Integratie van eindschermen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 node_modules
 dist
 public/generated
+public/over-ons
+public/videos
+public/v
+public/htmlHeadTags.html
 
 
 # local env files

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,7 +2,7 @@
   <div id="appWrapper" :class="{burgerMenuOpen: isBurgerMenuOpen}">
     <CookieBanner v-if="isCookieBannerOpen" @confirm="confirmCookies" />
     <Header :socialLinks="socialLinks" :isBurgerMenuOpen="isBurgerMenuOpen" @toggleBurgerMenu="toggleBurgerMenu" />
-    <MiniPlayer v-show="!isBurgerMenuOpen" v-if="playerVideo" :videos="videos" :playlists="playlists" :playerVideo="playerVideo" :isOnVideoPage="isOnVideoPage" @close="closePlayer" />
+    <MiniPlayer v-show="!isBurgerMenuOpen" v-if="playerVideo" :videos="videos" :playlists="playlists" :playerVideo="playerVideo" :recommendedVideoIds="recommendedVideoIds" :isAutoplay="isAutoplay" :isOnVideoPage="isOnVideoPage" @setCurrentVideoId="setCurrentVideoId" @close="closePlayer" />
     <main>
       <Hero :latestVideos="latestVideos" />
       <router-view v-slot="{ Component }">
@@ -76,7 +76,7 @@ export default {
 
     this.socialLinks = channelData.socialLinks
     this.aboutDesc = channelData.description
-    this.updateVideoInfo();
+    this.testPageForVideo();
 
     // Zorg dat het burgermenu sluit als het scherm te breed wordt
     window.addEventListener('resize', () => {
@@ -137,10 +137,13 @@ export default {
         this.pickRandom(this.videos.order, 4) // Suggereer willekeurige video's
       ]).filter((video) => video != this.playerVideo.id);
     },
-    updateVideoInfo() {
+    setCurrentVideoId(videoId) {
+      this.playerVideo = this.videos.values[videoId];
+      this.updateRecommendedVideoIds();
+    },
+    testPageForVideo() {
       if (this.videos && this.$route.name == 'Video') {
-        this.playerVideo = this.videos.values[this.$route.params.videoId];
-        this.updateRecommendedVideoIds();
+        this.setCurrentVideoId(this.$route.params.videoId);
         this.isOnVideoPage = true;
       } else {
         this.isOnVideoPage = false;
@@ -195,7 +198,7 @@ export default {
   },
   watch: {
     $route() {
-      this.updateVideoInfo();
+      this.testPageForVideo();
     }
   }
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -7,7 +7,7 @@
       <Hero :latestVideos="latestVideos" />
       <router-view v-slot="{ Component }">
         <transition name="fade" mode="in-out">
-          <component :is="Component" :channelName="channelName" :channelSubsFormatted="channelSubsFormatted" :videos="videos" :recommendedVideoIds="recommendedVideoIds" :playlists="playlists" :schoolYears="schoolYears" :playerVideo="playerVideo" :aboutDesc="aboutDesc" />
+          <component :is="Component" :channelName="channelName" :channelSubsFormatted="channelSubsFormatted" :aboutDesc="aboutDesc" :videos="videos" :recommendedVideoIds="recommendedVideoIds" :playlists="playlists" :schoolYears="schoolYears" :playerVideo="playerVideo" :isAutoplay="isAutoplay" @setAutoplay="isAutoplay => this.isAutoplay = isAutoplay" />
         </transition>
       </router-view>
     </main>
@@ -39,6 +39,7 @@ export default {
       playlists: null,
       schoolYears: null,
       playerVideo: null,
+      isAutoplay: true,
       channelName: null,
       channelSubsFormatted: null,
       socialLinks: null,

--- a/src/components/video/AutoPlay.vue
+++ b/src/components/video/AutoPlay.vue
@@ -1,0 +1,36 @@
+<template>
+    <div id="autoPlay">
+        <ToggleInput assignedId="autoPlaySetting" :checked="isAutoplay" @change="isChecked => $emit('setAutoplay', isChecked)" />
+        <label for="autoPlaySetting">Autoplay</label>
+    </div>
+</template>
+
+<script>
+import ToggleInput from './ToggleInput.vue';
+
+export default {
+    name: 'AutoPlay',
+    emits: [ 'setAutoplay' ],
+    components: {
+        ToggleInput
+    },
+    props: {
+        isAutoplay: Boolean
+    }
+}
+</script>
+
+<style lang="scss" scoped>
+    #autoPlay {
+        display: flex;
+        background: $sectionBackgroundDarker;
+        border: 1px solid $sectionBorderColor;
+        border-radius: 4px;
+        margin-bottom: 20px;
+        padding: 20px;
+    }
+    label {
+        margin-left: 20px;
+        color: $textColor;
+    }
+</style>

--- a/src/components/video/EndScreen.vue
+++ b/src/components/video/EndScreen.vue
@@ -1,15 +1,192 @@
 <template>
     <div id="endScreen">
+        <div id="autoPlayScreen" v-if="isAutoplay && !isAutoplayCancelled">
+            <button id="apCloseButton" class="icon" @click="cancelAutoplay" title="Autoplay annuleren" aria-label="Autoplay annuleren" tabindex="4"><fa icon="times" /></button>
+            <div id="apTimerBar">
+                <div id="apTimerProgress"></div>
+            </div>
+            <div id="apMainContent">
+                <h3 id="apTimerSub">Over {{autoplayCountdown}} seconden...</h3>
+                <VideoPreview :video="videos.values[recommendedVideoIds[0]]" :isPlaying="false" tabindex="4" />
+                <div id="apOptions">
+                    <button id="apCancel" class="btn" @click="cancelAutoplay" aria-label="Autoplay annuleren" tabindex="4">Annuleren</button>
+                    <button id="apContinue" class="btn" @click="continueAutoplay" aria-label="Autoplay verderzetten" tabindex="4">Afspelen</button>
+                </div>
+            </div>
+        </div>
+        <div id="recommendedScreen">
+            <h3 id="rsTitle">Misschien kijkt u ook naar...</h3>
+            <ul id="rsList" aria-label="Suggesties" tabindex="4">
+                <li v-for="videoId of ( !isAutoplay || isAutoplayCancelled ? recommendedVideoIds: recommendedVideoIds.slice(1) )" :key="videoId">
+                    <VideoPreview :video="videos.values[videoId]" :isPlaying="false" tabindex="4" />
+                </li>
+            </ul>
+        </div>
     </div>
 </template>
 
 <script>
+import VideoPreview from '../videos/VideoPreview.vue'
+
 export default {
     name: 'EndScreen',
+    components: {
+        VideoPreview
+    },
     props: {
         videos: Object,
         recommendedVideoIds: Array,
         isAutoplay: Boolean
+    },
+    emits: [ 'setCurrentVideoId' ],
+    data() {
+        return {
+            isAutoplayCancelled: false,
+            autoplayInterval: null,
+            autoplayCountdown: 10
+        }
+    },
+    methods: {
+        startAutoplay() {
+            this.autoplayInterval = setInterval(() => {
+                this.autoplayCountdown--;
+                if (this.autoplayCountdown == 0) {
+                    clearInterval(this.autoplayInterval);
+                    this.continueAutoplay();
+                }
+            }, 1000);
+        },
+        cancelAutoplay() {
+            this.isAutoplayCancelled = true;
+            clearInterval(this.autoplayInterval);
+        },
+        continueAutoplay() {
+            if (this.$route.name == 'Video') {
+                this.$router.push({
+                    name: 'Video',
+                    path: '/videos/:videoId/:videoPath',
+                    params: {
+                        videoId: this.recommendedVideoIds[0],
+                        videoPath: this.videos.values[this.recommendedVideoIds[0]].videoPath
+                    }
+                });
+            } else {
+                this.$emit('setCurrentVideoId', this.recommendedVideoIds[0]);
+            }
+        },
+        escapePressed(e) {
+            if (e.key == 'Escape' && !this.isAutoplayCancelled) this.cancelAutoplay();
+        }
+    },
+    mounted() {
+        if (this.isAutoplay) this.startAutoplay();
+        document.addEventListener('keyup', this.escapePressed, false);
+    },
+    unmounted() {
+        clearInterval(this.autoplayInterval)
+        document.removeEventListener('keyup', this.escapePressed, false);
+    },
+    watch: {
+        isAutoplay(bool) {
+            if (!bool) {
+                clearInterval(this.autoplayInterval);
+            } else {
+                if (!this.isAutoplayCancelled) {
+                    this.autoplayCountdown = 10;
+                    this.startAutoplay();
+                }
+            }
+        }
     }
 }
 </script>
+
+<style lang="scss" scoped>
+    $screenPadding: 40px;
+    $apCloseButtonSize: 1.2em;
+
+    #endScreen {
+        display: flex;
+        background: $videoBackground;
+        overflow: hidden;
+        color: $headingColor;
+    }
+    #autoPlayScreen {
+        position: relative;
+        flex: 1;
+        background: $videoBackgroundBrighter;
+        padding: $screenPadding;
+
+
+        h3 { font-size: 1em; }
+        #apCloseButton {
+            position: absolute;
+            top: $screenPadding;
+            right: $screenPadding;
+            font-size: $apCloseButtonSize;
+        }
+        #apTimerBar {
+            width: calc(100% - #{$apCloseButtonSize + .7em});
+            height: 4px;
+            background: rgba(255, 255, 255, .1);
+            margin-top: #{$apCloseButtonSize * .5};
+            margin-bottom: 15px;
+
+            #apTimerProgress {
+                height: 100%;
+                background-color: $accentColor;
+                animation: countDown 10s linear;
+                @keyframes countDown {
+                    from { width: 0; }
+                    to { width: 100%; }
+                }
+            }
+        }
+        #apMainContent {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-between;
+            height: calc(100% - #{60px + $screenPadding * .5});
+        }
+        .videoPreview {
+            width: 100%;
+            padding: 10%;
+        }
+        #apOptions {
+            display: flex;
+            width: 100%;
+
+            button {
+                margin: 0 20px;
+                flex: 1;
+            }
+            #apCancel {
+                background: #333749;
+            }
+        }
+    }
+    #recommendedScreen {
+        display: flex;
+        flex-direction: column;
+        flex: 2;
+        background: $videoBackground;
+        padding: $screenPadding;
+
+        #rsList {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(calc(200px + 7%), 1fr));
+            padding: 0 calc(5px + 3%);
+            list-style: none;
+            height: 0;
+            flex: 1;
+            margin: 40px 0;
+            overflow-y: scroll;
+
+            li a {
+                width: 100%;
+                padding: 20px 40px;
+                outline-offset: -10px;
+            }
+        }
+    }
+</style>

--- a/src/components/video/EndScreen.vue
+++ b/src/components/video/EndScreen.vue
@@ -1,5 +1,5 @@
 <template>
-    <div id="endScreen">
+    <div id="endScreen" :class="{onVideoPage: isOnVideoPage}">
         <div id="autoPlayScreen" v-if="isAutoplay && !isAutoplayCancelled">
             <button id="apCloseButton" class="icon" @click="cancelAutoplay" title="Autoplay annuleren" aria-label="Autoplay annuleren" tabindex="4"><fa icon="times" /></button>
             <div id="apTimerBar">
@@ -36,6 +36,7 @@ export default {
     props: {
         videos: Object,
         recommendedVideoIds: Array,
+        isOnVideoPage: Boolean,
         isAutoplay: Boolean
     },
     emits: [ 'setCurrentVideoId' ],
@@ -103,6 +104,8 @@ export default {
 
 <style lang="scss" scoped>
     $screenPadding: 40px;
+    $screenPaddingSlimmer: 20px;
+    $screenPaddingSlimmest: 15px;
     $apCloseButtonSize: 1.2em;
 
     #endScreen {
@@ -110,13 +113,70 @@ export default {
         background: $videoBackground;
         overflow: hidden;
         color: $headingColor;
+
+        &:not(.onVideoPage) {
+            #apMainContent {
+                height: calc(100% - 60px) !important;
+            }
+            #autoPlayScreen + #recommendedScreen {
+                display: none;
+            }
+            #autoPlayScreen {
+                padding: $screenPaddingSlimmer $screenPaddingSlimmest;
+    
+                #apCloseButton {
+                    display: none;
+                }
+                #apTimerBar {
+                    visibility: hidden;
+                    width: 100%;
+                    height: 0 !important;
+                    margin: 0 !important;
+                }
+                #apTimerSub {
+                    text-align: center;
+                }
+                .videoPreview {
+                    height: 80%;
+                    padding: 6% 10%;
+                    flex-direction: row;
+                    text-align: left;
+                }
+                #apOptions button {
+                    padding: 5px 16px;
+                }
+            }
+            #recommendedScreen {
+                padding: $screenPaddingSlimmer;
+
+                #rsTitle {
+                    display: none;
+                }
+                #rsList {
+                    display: block !important;
+                    margin: 25px 10px !important;
+
+                    li {
+                        width: 100%;
+                        margin: 0;
+
+                        .videoPreview {
+                            height: 80%;
+                            text-align: left;
+                            flex-direction: row;
+                        }
+                    }
+                }
+            }
+        }
     }
     #autoPlayScreen {
         position: relative;
         flex: 1;
         background: $videoBackgroundBrighter;
         padding: $screenPadding;
-
+        width: 100%;
+        box-sizing: border-box;
 
         h3 { font-size: 1em; }
         #apCloseButton {
@@ -148,10 +208,6 @@ export default {
             justify-content: space-between;
             height: calc(100% - #{60px + $screenPadding * .5});
         }
-        .videoPreview {
-            width: 100%;
-            padding: 10%;
-        }
         #apOptions {
             display: flex;
             width: 100%;
@@ -165,6 +221,13 @@ export default {
             }
         }
     }
+    .videoPreview {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        width: 100%;
+        padding: 10%;
+    }
     #recommendedScreen {
         display: flex;
         flex-direction: column;
@@ -174,18 +237,106 @@ export default {
 
         #rsList {
             display: grid;
-            grid-template-columns: repeat(auto-fill, minmax(calc(200px + 7%), 1fr));
+            grid-template-columns: repeat(auto-fill, minmax(calc(200px + 3%), 1fr));
             padding: 0 calc(5px + 3%);
             list-style: none;
             height: 0;
             flex: 1;
             margin: 40px 0;
+            overflow-x: hidden;
             overflow-y: scroll;
 
             li a {
                 width: 100%;
                 padding: 20px 40px;
                 outline-offset: -10px;
+            }
+        }
+    }
+    @media screen and (max-width: 920px) {
+        #endScreen.onVideoPage {
+            #autoPlayScreen + #recommendedScreen {
+                display: none;
+            }
+            #autoPlayScreen {
+                padding: $screenPadding calc(20%);
+    
+                #apTimerBar {
+                    width: 100%;
+                }
+                .videoPreview {
+                    height: 80%;
+                    text-align: left;
+                    flex-direction: row;
+                }
+            }
+        }
+    }
+    @media screen and (max-width: 650px) {
+        #endScreen.onVideoPage {
+            #recommendedScreen {
+                padding: $screenPaddingSlimmer;
+            }
+            #rsList {
+                display: block !important;
+                margin-top: 10px !important;
+
+                li {
+                    width: 80%;
+                    margin: 0 10%;
+
+                    .videoPreview {
+                        height: 80%;
+                        text-align: left;
+                        flex-direction: row;
+                    }
+                }
+            }
+        }
+    }
+    @media screen and (max-width: 600px) {
+        #endScreen.onVideoPage {
+            #apMainContent {
+                height: calc(100% - 60px) !important;
+            }
+            #apTimerSub {
+                text-align: center;
+            }
+            #apTimerBar {
+                visibility: hidden;
+                height: 0 !important;
+                margin: 0 !important;
+            }
+            #autoPlayScreen .videoPreview {
+                padding: 6% 10%;
+            }
+            #apOptions button {
+                padding: 5px 16px;
+            }
+        }
+    }
+    @media screen and (max-width: 480px) {
+        #endScreen.onVideoPage {
+            #autoPlayScreen {
+                padding-top: $screenPaddingSlimmest;
+                padding-left: $screenPaddingSlimmest;
+                padding-right: $screenPaddingSlimmest;
+
+                #apCloseButton {
+                    top: $screenPaddingSlimmest !important;
+                    right: $screenPaddingSlimmest !important;
+                }
+            }
+            #recommendedScreen li {
+                width: 100%;
+                margin: 0;
+            }
+        }
+    }
+    @media screen and (max-width: 400px) {
+        #endScreen.onVideoPage {
+            #rsTitle {
+                display: none;
             }
         }
     }

--- a/src/components/video/EndScreen.vue
+++ b/src/components/video/EndScreen.vue
@@ -1,0 +1,15 @@
+<template>
+    <div id="endScreen">
+    </div>
+</template>
+
+<script>
+export default {
+    name: 'EndScreen',
+    props: {
+        videos: Object,
+        recommendedVideoIds: Array,
+        isAutoplay: Boolean
+    }
+}
+</script>

--- a/src/components/video/MiniPlayer.vue
+++ b/src/components/video/MiniPlayer.vue
@@ -1,12 +1,12 @@
 <template>
     <div id="miniplayer" :class="{ onVideoPage: isOnVideoPage, playlistOpen: isPlaylistOpen }">
-        <VideoPlayer :video="playerVideo" :playerPlaylistInfo="playerPlaylistInfo" :isOnVideoPage="isOnVideoPage" @close="$emit('close')" />
+        <VideoPlayer :video="playerVideo" :playerPlaylistInfo="playerPlaylistInfo" :videos="videos" :recommendedVideoIds="recommendedVideoIds" :isAutoplay="isAutoplay" :isOnVideoPage="isOnVideoPage" @setCurrentVideoId="videoId => $emit('setCurrentVideoId', videoId)" @close="$emit('close')" />
         <div id="miniplayerTitle">
             <h2>{{playerVideo.title}}</h2>
             <button v-if="playerPlaylistInfo.playlistId != ''" id="expandPlaylist" class="icon" :title="isPlaylistOpen ? 'Afspeellijst verbergen' : 'Afspeellijst tonen'" @click="isPlaylistOpen = !isPlaylistOpen"></button>
         </div>
         <MountedTeleport to="#playlistContainer" pageName="Video">
-            <Playlist :videos="videos" :playlists="playlists" :currentVideoId="playerVideo.id" :playerPlaylistInfo="playerPlaylistInfo" />
+            <Playlist :videos="videos" :playlists="playlists" :currentVideoId="playerVideo.id" :playerPlaylistInfo="playerPlaylistInfo" :isOnVideoPage="isOnVideoPage" @setCurrentVideoId="videoId => $emit('setCurrentVideoId', videoId)" />
         </MountedTeleport>
     </div>
 </template>
@@ -18,7 +18,10 @@ import Playlist from './Playlist.vue';
 
 export default {
     name: 'MiniPlayer',
-    emits: [ 'close' ],
+    emits: [
+        'close',
+        'setCurrentVideoId'
+    ],
     components: {
         VideoPlayer,
         MountedTeleport,
@@ -28,6 +31,8 @@ export default {
         videos: Object,
         playlists: Array,
         playerVideo: Object,
+        recommendedVideoIds: Array,
+        isAutoplay: Boolean,
         isOnVideoPage: Boolean
     },
     data() {

--- a/src/components/video/ToggleInput.vue
+++ b/src/components/video/ToggleInput.vue
@@ -1,0 +1,81 @@
+<template>
+    <label class="toggleInput">
+        <input type="checkbox" :id="assignedId" class="tiCheckbox" :checked="checked" @change="e => $emit('change', e.currentTarget.checked)">
+        <div class="tiSlider"></div>
+    </label>
+</template>
+
+<script>
+export default {
+    name: 'ToggleInput',
+    props: {
+        assignedId: {
+            type: String,
+            default: ''
+        },
+        checked: {
+            type: Boolean,
+            default: false
+        }
+    },
+    emits: [ 'change' ]
+}
+</script>
+
+<style lang="scss" scoped>
+    $size: 24px;
+    $dialSizeFrac: .6;
+    $borderWidth: 2px;
+
+    .toggleInput {
+        display: inline-block;
+        position: relative;
+        width: #{$size * 2};
+        height: $size;
+        margin: 0;
+        cursor: pointer;
+
+        &:focus-within {
+            outline: 2px solid $accentColor;
+            outline-offset: 2px;
+        }
+
+        .tiCheckbox {
+            opacity: 0;
+            width: 0;
+            height: 0;
+        }
+        .tiSlider {
+            position: absolute;
+            top: 0;
+            width: 100%;
+            height: 100%;
+            background-color: rgba(0, 0, 0, .2);
+            border: $borderWidth solid $sectionBorderColor;
+            border-radius: $size;
+            box-sizing: border-box;
+            overflow: hidden;
+            transition: background-color .1s cubic-bezier(.46,.03,.52,.96);
+
+            &::before {
+                content: '';
+                position: absolute;
+                background-color: $sectionBorderColor;
+                width: #{$size * $dialSizeFrac};
+                height: #{$size * $dialSizeFrac};
+                border-radius: 50%;
+                top: #{$size * (1 - $dialSizeFrac) / 2 - $borderWidth};
+                left: #{$size * (1 - $dialSizeFrac) / 2 - $borderWidth};
+                transition: transform .3s cubic-bezier(.46,.03,.52,.96),
+                            background-color .3s cubic-bezier(.46,.03,.52,.96);
+            }
+        }
+    }
+    .tiCheckbox:checked + .tiSlider {
+        background-color: rgba(200, 200, 200, .2);
+        &::before {
+            background-color: $headingColorBright;
+            transform: translateX(#{$size * ($dialSizeFrac + .5) - $borderWidth})
+        }
+    }
+</style>

--- a/src/components/video/VideoPlayer.vue
+++ b/src/components/video/VideoPlayer.vue
@@ -51,7 +51,7 @@
                         <div id="tlHoverTimeTooltip" :style="{left: this.relativeMouseX + 'px'}">{{this.videoTimeHoveringFormatted}}</div>
                     </div>
                 </div>
-                <EndScreen v-if="currentPlayerState == 0" :videos="videos" :recommendedVideoIds="recommendedVideoIds" :isAutoplay="isAutoplay" @setCurrentVideoId="videoId => $emit('setCurrentVideoId', videoId)" />
+                <EndScreen v-if="currentPlayerState == 0" :videos="videos" :recommendedVideoIds="recommendedVideoIds" :isAutoplay="isAutoplay" :isOnVideoPage="isOnVideoPage" @setCurrentVideoId="videoId => $emit('setCurrentVideoId', videoId)" />
                 <div id="error" v-if="errorVal != 0">
                     <div class="overlay">
                         <button class="close icon" aria-label="Afsluiten" @click.stop="close"><fa icon="times" /></button>
@@ -551,6 +551,7 @@ export default {
                             left: 0;
                             height: 100px;
                             width: 100%;
+                            pointer-events: none;
                             @include scrimGradient(rgb(0, 0, 0), 'to top');
                         }
                         &::after {

--- a/src/components/video/VideoPlayer.vue
+++ b/src/components/video/VideoPlayer.vue
@@ -10,7 +10,7 @@
                             <button class="close icon" tabindex="3" aria-label="Afsluiten" @click.stop="close"><fa icon="times" /></button>
                             <button class="expand icon" tabindex="2" aria-label="Vergroten" @click.stop="expand"><fa icon="external-link-alt" rotation="270" /></button>
                             <div class="controls">
-                                <button class="pausePlay icon" tabindex="5" :aria-label="isPaused ? 'Afspelen' : 'Pauzeren'" @click.stop="pausePlay(false)"><fa :icon="isPaused ? 'play' : 'pause'" /></button>
+                                <button class="pausePlay icon" tabindex="6" :aria-label="isPaused ? 'Afspelen' : 'Pauzeren'" @click.stop="pausePlay(false)"><fa :icon="isPaused ? 'play' : 'pause'" /></button>
                                 <button class="volume icon" tabindex="-1" aria-label="Volume" @mouseover="this.isVolumeWrapperOpen = true"><fa :icon="this.isMuted ? 'volume-mute' : (this.volume == 0 ? 'volume-off' : (this.volume < 70 ? 'volume-down' : 'volume-up'))" /></button>
                                 <div id="time" v-if="$refs.youtube">
                                     <span id="currentTime">{{videoTimeSecFormatted}}</span>
@@ -18,10 +18,10 @@
                                     <span id="maxTime">{{video.durationFormatted}}</span>
                                 </div>
                                 <div class="floatRight" v-if="isOnVideoPage">
-                                    <button class="youtubeBtn icon" tabindex="8" aria-label="Op YouTube bekijken" @click.stop="watchOnYoutube"><fa :icon="['fab', 'youtube']" /></button>
-                                    <button class="playbackRate icon" tabindex="8" ref="playbackRateBtn" aria-label="Snelheid" @click.stop="togglePlaybackRateModal"><fa icon="tachometer-alt" /></button>
-                                    <button class="miniplayer icon" tabindex="10" aria-label="Minimalizeren" @click="gotoVideos"><fa icon="external-link-alt" rotation="90" /></button>
-                                    <button class="fullscreen icon" tabindex="10" aria-label="Volledig scherm" @click="toggleFullscreenMode"><fa :icon="this.isInFullscreenMode ? 'compress' : 'expand'" /></button>
+                                    <button class="youtubeBtn icon" tabindex="9" aria-label="Op YouTube bekijken" @click.stop="watchOnYoutube"><fa :icon="['fab', 'youtube']" /></button>
+                                    <button class="playbackRate icon" tabindex="9" ref="playbackRateBtn" aria-label="Snelheid" @click.stop="togglePlaybackRateModal"><fa icon="tachometer-alt" /></button>
+                                    <button class="miniplayer icon" tabindex="11" aria-label="Minimalizeren" @click="gotoVideos"><fa icon="external-link-alt" rotation="90" /></button>
+                                    <button class="fullscreen icon" tabindex="11" aria-label="Volledig scherm" @click="toggleFullscreenMode"><fa :icon="this.isInFullscreenMode ? 'compress' : 'expand'" /></button>
                                 </div>
                             </div>
                         </div>
@@ -32,26 +32,26 @@
                         </div>
                     </div>
                     <div id="volumeSliderOuterWrapper" :class="{open: isVolumeWrapperOpen}" ref="volumeSliderOuterWrapper" @mouseleave="mouseLeaveVolumeSliderWrapper">
-                        <div id="volumeSliderInnerWrapper" tabindex="7" @mousedown.left="startDragVolumeSlider" @keydown="sliderVolumeKeydown" role="slider" aria-label="volume" aria-valuemin="0" aria-valuemax="100" :aria-valuenow="volume" :aria-valuetext="`${this.volume}%`">
+                        <div id="volumeSliderInnerWrapper" tabindex="8" @mousedown.left="startDragVolumeSlider" @keydown="sliderVolumeKeydown" role="slider" aria-label="volume" aria-valuemin="0" aria-valuemax="100" :aria-valuenow="volume" :aria-valuetext="`${this.volume}%`">
                             <div id="volumeSlider" ref="volumeSlider">
                                 <div id="volumeSliderLevel" :style="{height: this.isMuted ? '0' : this.volume + '%'}" />
                             </div>
                         </div>
-                        <button class="muteAudio icon" tabindex="6" :aria-label="isMuted ? 'Geluid inschakelen' : 'Geluid uitschakelen'" @click="toggleMute"></button>
+                        <button class="muteAudio icon" tabindex="7" :aria-label="isMuted ? 'Geluid inschakelen' : 'Geluid uitschakelen'" @click="toggleMute"></button>
                     </div>
                     <div id="playbackRateModal" ref="playbackRateModal" v-show="isPlaybackRateModalOpen" @keydown.esc.stop="togglePlaybackRateModal">
                         <ul role="listbox" aria-label="Snelheid kiezen">
-                            <li :key="option" v-for="option in availablePlaybackRates" :class="{selected: this.playbackRate == option}" tabindex="9" @click="setPlaybackRate(option)" @keydown.enter.space.prevent="setPlaybackRate(option)" role="option" :aria-label="option == 1 ? 'originele snelheid' : `${option*100}% van originele snelheid`" :aria-selected="this.playbackRate == option">{{option}}</li>
+                            <li :key="option" v-for="option in availablePlaybackRates" :class="{selected: this.playbackRate == option}" tabindex="10" @click="setPlaybackRate(option)" @keydown.enter.space.prevent="setPlaybackRate(option)" role="option" :aria-label="option == 1 ? 'originele snelheid' : `${option*100}% van originele snelheid`" :aria-selected="this.playbackRate == option">{{option}}</li>
                         </ul>
                     </div>
-                    <div id="timeline" :tabindex="this.isOnVideoPage ? 4 : 11" :class="{dragging: this.draggingType == 1}" ref="timeline" @mousemove="calculateHoveredTimelineTime" @mousedown.left="startDragTimeline" @keydown="sliderTimelineKeydown" role="slider" aria-label="tijdlijn" aria-valuemin="0" :aria-valuemax="video.durationSec" :aria-valuenow="videoTimeSec" :aria-valuetext="timelineAriaText">
+                    <div id="timeline" :tabindex="this.isOnVideoPage ? 5 : 12" :class="{dragging: this.draggingType == 1}" ref="timeline" @mousemove="calculateHoveredTimelineTime" @mousedown.left="startDragTimeline" @keydown="sliderTimelineKeydown" role="slider" aria-label="tijdlijn" aria-valuemin="0" :aria-valuemax="video.durationSec" :aria-valuenow="videoTimeSec" :aria-valuetext="timelineAriaText">
                         <div id="tlBackground"></div>
                         <div id="tlBuffered" :style="{width: this.videoLoadedFrac * 100 + '%'}"></div>
                         <div id="tlProgress" :style="{width: this.videoTimeSec / this.video.durationSec * 100 + '%'}"></div>
                         <div id="tlHoverTimeTooltip" :style="{left: this.relativeMouseX + 'px'}">{{this.videoTimeHoveringFormatted}}</div>
                     </div>
                 </div>
-                <EndScreen v-if="currentPlayerState == 0" :videos="videos" :recommendedVideoIds="recommendedVideoIds" :isAutoplay="isAutoplay" />
+                <EndScreen v-if="currentPlayerState == 0" :videos="videos" :recommendedVideoIds="recommendedVideoIds" :isAutoplay="isAutoplay" @setCurrentVideoId="videoId => $emit('setCurrentVideoId', videoId)" />
                 <div id="error" v-if="errorVal != 0">
                     <div class="overlay">
                         <button class="close icon" aria-label="Afsluiten" @click.stop="close"><fa icon="times" /></button>
@@ -419,6 +419,7 @@ export default {
         },
         toggledFullscreen() {
             this.isInFullscreenMode = document.fullscreenElement || document.webkitFullscreenElement || document.mozFullScreenElement;
+            if (!this.isInFullscreenMode) document.activeElement.blur();
         },
         togglePlaybackRateModal() {
             this.isPlaybackRateModalOpen = !this.isPlaybackRateModalOpen;

--- a/src/components/video/VideoPlayer.vue
+++ b/src/components/video/VideoPlayer.vue
@@ -10,7 +10,7 @@
                             <button class="close icon" tabindex="3" aria-label="Afsluiten" @click.stop="close"><fa icon="times" /></button>
                             <button class="expand icon" tabindex="2" aria-label="Vergroten" @click.stop="expand"><fa icon="external-link-alt" rotation="270" /></button>
                             <div class="controls">
-                                <button class="pausePlay icon" tabindex="6" :aria-label="isPaused ? 'Afspelen' : 'Pauzeren'" @click.stop="pausePlay(false)"><fa :icon="isPaused ? 'play' : 'pause'" /></button>
+                                <button class="pausePlay icon" tabindex="6" :aria-label="currentPlayerState == 0 ? 'Herhalen' : (isPaused ? 'Afspelen' : 'Pauzeren')" @click.stop="currentPlayerState == 0 ? replay() : pausePlay(false)"><fa :icon="currentPlayerState == 0 ? 'rotate-left' : (isPaused ? 'play' : 'pause')" /></button>
                                 <button class="volume icon" tabindex="-1" aria-label="Volume" @mouseover="this.isVolumeWrapperOpen = true"><fa :icon="this.isMuted ? 'volume-mute' : (this.volume == 0 ? 'volume-off' : (this.volume < 70 ? 'volume-down' : 'volume-up'))" /></button>
                                 <div id="time" v-if="$refs.youtube">
                                     <span id="currentTime">{{videoTimeSecFormatted}}</span>
@@ -153,6 +153,12 @@ export default {
             this.isPaused = false;
             this.errorVal = 0;
             if (!this.isOnVideoPage) this.setDimensionsMiniPlayer();
+        },
+        replay() {
+            this.setVideoTime(0);
+            this.$refs.youtube.playVideo();
+            this.isPaused = false;
+            this.resetIdleTimer();
         },
         setDimensionsMiniPlayer() {
             let $video = this.$refs.video.firstChild;

--- a/src/components/videos/VideoPreview.vue
+++ b/src/components/videos/VideoPreview.vue
@@ -1,12 +1,14 @@
 <template>
     <router-link class="videoPreview" :to="{ name: 'Video', path: '/videos/:videoId/:videoPath', params: { videoId: video.id, videoPath: video.videoPath } }" :aria-label="video.title">
-        <div class="thumb" :style="`background: linear-gradient(rgba(0, 0, 0, .1), rgba(0, 0, 0, .1)), url('${video.thumb}')`">
-            <div class="foreground">
-                <div class="expand" v-if="isPlaying">
-                    <fa icon="external-link-alt" />
-                </div>
-                <div class="play" v-else>
-                    <fa icon="play" />
+        <div class="thumb">
+            <div class="thumbInnerWrapper" :style="`background: linear-gradient(rgba(0, 0, 0, .1), rgba(0, 0, 0, .1)), url('${video.thumb}')`">
+                <div class="foreground">
+                    <div class="expand" v-if="isPlaying">
+                        <fa icon="external-link-alt" />
+                    </div>
+                    <div class="play" v-else>
+                        <fa icon="play" />
+                    </div>
                 </div>
             </div>
         </div>
@@ -30,11 +32,12 @@ export default {
     .videoPreview {
         display: inline-block;
         box-sizing: border-box;
+        text-align: center;
         padding: 10px;
         cursor: pointer;
 
         &:hover, &:focus:focus-visible {
-            .thumb {
+            .thumbInnerWrapper {
                 background-size: 110% !important;
             }
             .foreground {
@@ -47,14 +50,20 @@ export default {
         }
     }
     .thumb {
+        display: flex;
+        position: relative;
+        flex-direction: column;
+        justify-content: center;
+        width: 100%;
+        border-radius: 4px;
+        overflow: hidden;
+    }
+    .thumbInnerWrapper {
         position: relative;
         width: 100%;
         padding-top: 56.25%;
         background-size: 100% !important;
         background-position: center center !important;
-        box-shadow: 0px 0px 10px 2px rgba(0, 0, 0, .2);
-        border-radius: 4px;
-        overflow: hidden;
         transition: background-size .4s ease-in-out;
     }
     .foreground {
@@ -64,6 +73,7 @@ export default {
         top: 0;
         width: 100%;
         height: 100%;
+        box-shadow: 0px 0px 10px 2px rgba(0, 0, 0, .2);
         background-color: rgba(0, 0, 0, .4);
 
         .expand {
@@ -83,10 +93,12 @@ export default {
         }
     }
     .title {
-        display: inline-block;
+        display: flex;
+        position: relative;
+        flex-direction: column;
+        justify-content: center;
         color: $textColorGray;
         padding: 10px 10px;
-        text-align: center;
         width: 100%;
         box-sizing: border-box;
         font-size: .9em;

--- a/src/globalvariables.scss
+++ b/src/globalvariables.scss
@@ -13,6 +13,7 @@ $sectionBackgroundDark: #21242e;
 $sectionBackgroundDarker: #1e2029;
 $sectionBorderColor: #353550;
 $videoBackground: #0f121b;
+$videoBackgroundBrighter: #161925;
 $brandingGradient: linear-gradient(to right, #1c829e 12.5%, #15af46 25%, #afbe27 37.5%, #fff422 50%, #f4a636 62.5%, #dc4727 75%, #cd2673 87.5%, #917ab6 100%);
 // $brandingGradient: linear-gradient(to right, #1c829e 12.5%, #15af46 12.5%, #15af46 25%, #afbe27 25%, #afbe27 37.5%, #fff422 37.5%, #fff422 50%, #f4a636 50%, #f4a636 62.5%, #dc4727 62.5%, #dc4727 75%, #cd2673 75%, #cd2673 87.5%, #917ab6 87.5%, #917ab6 100%);
 $pageTransitionFunction: cubic-bezier(.2,.91,.24,.94);

--- a/src/globalvariables.scss
+++ b/src/globalvariables.scss
@@ -12,6 +12,7 @@ $sectionBackgroundSemiLight: #252833;
 $sectionBackgroundDark: #21242e;
 $sectionBackgroundDarker: #1e2029;
 $sectionBorderColor: #353550;
+$videoBackground: #0f121b;
 $brandingGradient: linear-gradient(to right, #1c829e 12.5%, #15af46 25%, #afbe27 37.5%, #fff422 50%, #f4a636 62.5%, #dc4727 75%, #cd2673 87.5%, #917ab6 100%);
 // $brandingGradient: linear-gradient(to right, #1c829e 12.5%, #15af46 12.5%, #15af46 25%, #afbe27 25%, #afbe27 37.5%, #fff422 37.5%, #fff422 50%, #f4a636 50%, #f4a636 62.5%, #dc4727 62.5%, #dc4727 75%, #cd2673 75%, #cd2673 87.5%, #917ab6 87.5%, #917ab6 100%);
 $pageTransitionFunction: cubic-bezier(.2,.91,.24,.94);

--- a/src/main.js
+++ b/src/main.js
@@ -1,14 +1,14 @@
 import { createApp } from 'vue'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { library } from '@fortawesome/fontawesome-svg-core'
-import { faExternalLinkAlt, faTimes, faPause, faPlay, faVolumeMute, faVolumeOff, faVolumeDown, faVolumeUp, faTachometerAlt, faExpand, faCompress, faShareAlt, faBars, faRepeat, faShuffle } from '@fortawesome/free-solid-svg-icons'
+import { faExternalLinkAlt, faTimes, faPause, faPlay, faRotateLeft, faVolumeMute, faVolumeOff, faVolumeDown, faVolumeUp, faTachometerAlt, faExpand, faCompress, faShareAlt, faBars, faRepeat, faShuffle } from '@fortawesome/free-solid-svg-icons'
 import { faDiscord, faFacebookMessenger, faWhatsapp, faFacebook, faInstagram, faYoutube, faSnapchat, faTiktok, faTwitch, faTwitter, faWix, faWordpress, faSquarespace, faGithub, faGoogle } from '@fortawesome/free-brands-svg-icons'
 import App from './App.vue'
 import setupRouter from './router.js'
 
 library.add(
     faDiscord, faFacebookMessenger, faWhatsapp, faFacebook, faInstagram, faYoutube, faSnapchat, faTiktok, faTwitch, faTwitter, faWix, faWordpress, faSquarespace, faGithub, faGoogle,
-    faExternalLinkAlt, faTimes, faPause, faPlay, faVolumeMute, faVolumeOff, faVolumeDown, faVolumeUp, faTachometerAlt, faExpand, faCompress, faShareAlt, faBars, faRepeat, faShuffle
+    faExternalLinkAlt, faTimes, faPause, faPlay, faRotateLeft, faVolumeMute, faVolumeOff, faVolumeDown, faVolumeUp, faTachometerAlt, faExpand, faCompress, faShareAlt, faBars, faRepeat, faShuffle
 );
 
 setupRouter().then(router =>

--- a/src/views/Video.vue
+++ b/src/views/Video.vue
@@ -89,7 +89,7 @@ export default {
         position: relative;
         width: 100%;
         padding-top: 56.25%;
-        background-color: #1a1d25;
+        background-color: $videoBackground;
         border-radius: 4px;
         margin-bottom: 25px;
         overflow: hidden;

--- a/src/views/Video.vue
+++ b/src/views/Video.vue
@@ -22,6 +22,7 @@
             </section>
             <aside id="sidebar" v-if="recommendedVideoIds">
                 <div id="playlistContainer"><!-- Afspeellijst wordt aan dit element gekoppeld --></div>
+                <AutoPlay :isAutoplay="isAutoplay" @setAutoplay="isAutoplay => $emit('setAutoplay', isAutoplay)" />
                 <VideoGallery title="Enkele suggesties" :videos="videos" :videoIds="recommendedVideoIds" :playerVideo="playerVideo" :shownVideoCount="shownRecommendedVideos" @increaseShownVideoCount="shownRecommendedVideos += 3" :isLoadedByRequest="false" />
             </aside>
         </div>
@@ -29,19 +30,23 @@
 </template>
 
 <script>
+import AutoPlay from '../components/video/AutoPlay.vue'
 import VideoGallery from '../components/videos/VideoGallery.vue'
 import ShareLightBox from '../components/ShareLightBox.vue'
 
 export default {
     name: 'Video',
+    emits: [ 'setAutoplay' ],
     props: {
         recommendedVideoIds: Array,
         videos: Object,
-        playerVideo: Object
+        playerVideo: Object,
+        isAutoplay: Boolean
     },
     components: {
         VideoGallery,
-        ShareLightBox
+        ShareLightBox,
+        AutoPlay
     },
     data() {
         return {
@@ -138,6 +143,9 @@ export default {
         #videoHeading {
             flex-direction: column;
             align-items: unset;
+        }
+        #autoPlay {
+            justify-content: center;
         }
     }
     @media screen and (max-width: $videoPageRescale1Viewport) {


### PR DESCRIPTION
Op het einde van een video worden nu eindschermen afgebeeld: een autoplayscherm die een volgende video aankondigt en een scherm met suggesties voor andere video's. Na tien seconden gaat de autoplay af (tenzij hij uit staat of is geannuleerd). Je kan de autoplay uitschakelen a.d.h.v. een instelling rechts van de video of eronder.

Verder spelen video's in een afspeellijst vanaf nu correct na elkaar automatisch af. Ten slotte kan de gebruiker de huidige video aanpassen door in de afspeellijst te klikken zonder dat hij of zij daardoor persé wordt doorgevoerd naar een videopagina.