### PR TITLE
Herschikking van HTML-elementen

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,19 +25,30 @@
     <meta name="twitter:image" content="https://oinc.olva.be/generated/img/web/banner_youtube.webp">
     <!-- Favicon -->
     <link rel="icon" href="favicon.ico">
+    <!-- Preload script -->
+    <script type="text/javascript">
+      // Maak laadscherm
+      let $loadingScreen = document.createElement('div');
+      $loadingScreen.id = 'loadingScreen';
+      $loadingScreen.innerText = "Laden...";
+      setTimeout(() => {
+        // Verstop noscript wrapper
+        document.getElementById('noscriptWrapper').style.display = 'none';
+        // Plak laadscherm aan body
+        document.body.prepend($loadingScreen);
+      }, 10);
+
+      // Verstop alle preview-elementen
+      let $style = document.createElement('style');
+      $style.innerText = ".preview { display: none; } #loadingScreen { color: white; }"
+      document.head.appendChild($style);
+    </script>
     <!-- Content scripts and styles -->
   </head>
   <body style="background-color: black; overflow-x: hidden;">
     <div id="noscriptWrapper">
       <noscript>
         <iframe src="/enablejs.html" frameborder="0" style="width: 100%; height: 100vh"></iframe>
-        <style>
-          body {
-            margin: 0;
-            padding: 0;
-            min-height: 100vh;
-          }
-        </style>
       </noscript>
     </div>
 

--- a/public/index.html
+++ b/public/index.html
@@ -28,16 +28,52 @@
     <!-- Content scripts and styles -->
   </head>
   <body style="background-color: black; overflow-x: hidden;">
-    <noscript>
-      <iframe src="/enablejs.html" frameborder="0" style="width: 100%; height: 100vh"></iframe>
-      <style>
-        body {
-          margin: 0;
-          padding: 0;
-          min-height: 100vh;
-        }
-      </style>
-    </noscript>
+    <div id="noscriptWrapper">
+      <noscript>
+        <iframe src="/enablejs.html" frameborder="0" style="width: 100%; height: 100vh"></iframe>
+        <style>
+          body {
+            margin: 0;
+            padding: 0;
+            min-height: 100vh;
+          }
+        </style>
+      </noscript>
+    </div>
+
+    <div id="modals" class="preview"></div>
+
+    <header id="header" class="preview"></header>
+
+    <div id="miniplayer"></div>
+
+    <main>
+      <section id="hero" class="preview">
+        <h1>OINC - OLVA's Informatie, Nieuws en Cultuur</h1>
+      </section>
+      <div id="viewContent" class="preview"></div>
+    </main>
+
+    <footer id="footer" class="preview"></footer>
+
+    <div id="app"></div>
+
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+        min-height: 100vh;
+      }
+      #noscriptWrapper {
+        min-height: 100vh;
+      }
+      .preview h1 {
+        margin: 30px 0;
+        font-size: 2em;
+        text-align: center;
+        color: lightblue;
+      }
+    </style>
 
     <script type="text/javascript">
       // Single Page Apps for GitHub Pages

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,18 +1,16 @@
 <template>
-  <div id="appWrapper" :class="{burgerMenuOpen: isBurgerMenuOpen}">
-    <CookieBanner v-if="isCookieBannerOpen" @confirm="confirmCookies" />
-    <Header :socialLinks="socialLinks" :isBurgerMenuOpen="isBurgerMenuOpen" @toggleBurgerMenu="toggleBurgerMenu" />
-    <MiniPlayer v-show="!isBurgerMenuOpen" v-if="playerVideo" :videos="videos" :playlists="playlists" :playerVideo="playerVideo" :recommendedVideoIds="recommendedVideoIds" :isAutoplay="isAutoplay" :isOnVideoPage="isOnVideoPage" @setCurrentVideoId="setCurrentVideoId" @close="closePlayer" />
-    <main>
-      <Hero :latestVideos="latestVideos" />
-      <router-view v-slot="{ Component }">
-        <transition name="fade" mode="in-out">
-          <component :is="Component" :channelName="channelName" :channelSubsFormatted="channelSubsFormatted" :aboutDesc="aboutDesc" :videos="videos" :recommendedVideoIds="recommendedVideoIds" :playlists="playlists" :schoolYears="schoolYears" :playerVideo="playerVideo" :isAutoplay="isAutoplay" @setAutoplay="isAutoplay => this.isAutoplay = isAutoplay" />
-        </transition>
-      </router-view>
-    </main>
-    <Footer :socialLinks="socialLinks" />
-  </div>
+  <teleport to="#header"><Header :socialLinks="socialLinks" :isBurgerMenuOpen="isBurgerMenuOpen" @toggleBurgerMenu="toggleBurgerMenu" /></teleport>
+  <teleport to="#modals"><CookieBanner v-if="isCookieBannerOpen" @confirm="confirmCookies" /></teleport>
+  <teleport to="#miniplayer"><MiniPlayer v-show="!isBurgerMenuOpen" v-if="playerVideo" :videos="videos" :playlists="playlists" :playerVideo="playerVideo" :recommendedVideoIds="recommendedVideoIds" :isAutoplay="isAutoplay" :isOnVideoPage="isOnVideoPage" @setCurrentVideoId="setCurrentVideoId" @close="closePlayer" /></teleport>
+  <teleport to="#hero"><Hero :latestVideos="latestVideos" /></teleport>
+  <teleport to="#viewContent">
+    <router-view v-slot="{ Component }">
+      <transition name="fade" mode="in-out">
+        <component :is="Component" :channelName="channelName" :channelSubsFormatted="channelSubsFormatted" :aboutDesc="aboutDesc" :videos="videos" :recommendedVideoIds="recommendedVideoIds" :playlists="playlists" :schoolYears="schoolYears" :playerVideo="playerVideo" :isAutoplay="isAutoplay" @setAutoplay="isAutoplay => this.isAutoplay = isAutoplay" />
+      </transition>
+    </router-view>
+  </teleport>
+  <teleport to="#footer"><Footer :socialLinks="socialLinks" /></teleport>
 </template>
 
 <script>
@@ -47,6 +45,17 @@ export default {
       isOnVideoPage: null,
       isBurgerMenuOpen: false,
       isCookieBannerOpen: !this.getCookie('cookiesAccepted')
+    }
+  },
+  beforeCreate() {
+    // Verstop noscript wrapper
+    document.getElementById('noscriptWrapper').style.display = 'none';
+
+    // Verwijder preview content
+    let $previewElements = document.getElementsByClassName('preview');
+    while ($previewElements.length > 0) {
+      $previewElements[0].textContent = '';
+      $previewElements[0].classList.remove('preview');
     }
   },
   async created() {

--- a/src/App.vue
+++ b/src/App.vue
@@ -48,15 +48,15 @@ export default {
     }
   },
   beforeCreate() {
-    // Verstop noscript wrapper
-    document.getElementById('noscriptWrapper').style.display = 'none';
-
     // Verwijder preview content
     let $previewElements = document.getElementsByClassName('preview');
     while ($previewElements.length > 0) {
       $previewElements[0].textContent = '';
       $previewElements[0].classList.remove('preview');
     }
+
+    // Verstop laadscherm
+    document.getElementById('loadingScreen').style.display = 'none';
   },
   async created() {
     let channelData = await this.fetchChannelData()

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -1,5 +1,5 @@
 <template>
-    <footer>
+    <div id="footerInnerWrapper">
         <div id="footerMain">
             <div class="container">
                 <img class="logo" src="/logo.svg" alt="Logo OINC">
@@ -27,7 +27,7 @@
                 <a id="footerDisclaimerPrivacy" class="link" href="https://olva.be/privacy/" target="_blank">Disclaimer / Privacy</a>
             </div>
         </div>
-    </footer>
+    </div>
 </template>
 
 <script>
@@ -45,7 +45,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-    footer {
+    #footerInnerWrapper {
         position: relative;
         background-color: #1b1b1b;
     }

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,5 +1,5 @@
 <template>
-    <header :class="{burgerMenuOpen: isBurgerMenuOpen, enhanceBackground: isBackgroundEnhanced}">
+    <div id="headerInnerWrapper" :class="{burgerMenuOpen: isBurgerMenuOpen, enhanceBackground: isBackgroundEnhanced}">
         <div class="container">
             <div :class="['logo', {'enlarged': this.$route.name == 'Home' && !isBackgroundEnhanced}]">
                 <router-link to="/" @click="enterPage" aria-label="Terug naar de startpagina gaan" tabindex="1">
@@ -26,7 +26,7 @@
                 </ul>
             </nav>
         </div>
-    </header>
+    </div>
 </template>
 
 <script>
@@ -75,7 +75,7 @@ export default {
     @use '../mixins/scrim-gradient.scss' as *;
     @use 'sass:math';
 
-    header {
+    #headerInnerWrapper {
         position: fixed;
         top: 0; left: 0;
         height: $headerSize;

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -2,22 +2,22 @@
     <div id="headerInnerWrapper" :class="{burgerMenuOpen: isBurgerMenuOpen, enhanceBackground: isBackgroundEnhanced}">
         <div class="container">
             <div :class="['logo', {'enlarged': this.$route.name == 'Home' && !isBackgroundEnhanced}]">
-                <router-link to="/" @click="enterPage" aria-label="Terug naar de startpagina gaan" tabindex="1">
+                <router-link to="/" @click="enterPage" aria-label="Terug naar de startpagina gaan">
                     <img src="/logo.svg" alt="Logo OINC">
                 </router-link>
             </div>
             <button id="burgerMenu" class="icon" @click="$emit('toggleBurgerMenu')" aria-label="Menu">
-                <fa :icon="isBurgerMenuOpen ? 'times' : 'bars'" tabindex="1" />
+                <fa :icon="isBurgerMenuOpen ? 'times' : 'bars'" />
             </button>
             <nav>
                 <ul id="headerInternalLinks" aria-label="Pagina's van deze website">
-                    <li data-list-item="home"><router-link to="/" @click="enterPage" tabindex="1">Home</router-link></li>
-                    <li data-list-item="videos"><router-link to="/videos" @click="enterPage" tabindex="1">Video's</router-link></li>
-                    <li data-list-item="over-ons"><router-link to="/over-ons" @click="enterPage" tabindex="1">Over ons</router-link></li>
+                    <li data-list-item="home"><router-link to="/" @click="enterPage">Home</router-link></li>
+                    <li data-list-item="videos"><router-link to="/videos" @click="enterPage">Video's</router-link></li>
+                    <li data-list-item="over-ons"><router-link to="/over-ons" @click="enterPage">Over ons</router-link></li>
                 </ul>
                 <ul id="headerExternalLinks" aria-label="Gerelateerde links">
                     <li :key="link" v-for="link in socialLinks" :aria-label="link.name">
-                        <a :href="link.url" :title="link.title" target="_blank" :class="{'olva': link.name == 'olva'}" tabindex="1">
+                        <a :href="link.url" :title="link.title" target="_blank" :class="{'olva': link.name == 'olva'}">
                             <img src="../assets/olva_logo.webp" alt="olva" v-if="link.name == 'olva'">
                             <fa :icon="['fab', link.name]" v-else-if="link.iconAvailable" />
                             <span v-else>{{link.title}}</span>

--- a/src/components/Hero.vue
+++ b/src/components/Hero.vue
@@ -1,14 +1,14 @@
 <template>
-    <section
+    <div
         v-if="latestVideos"
-        id="hero"
+        id="heroInnerWrapper"
         :style="{ '--heroHeight': heroHeight, 'z-index': this.page == 'Home' ? 0 : -1 }"
         :aria-label="page == 'Home' ? 'Slideshow van laatste video\'s' : (page != 'Video' ? 'Strook met titel van pagina' : 'Niet-zichtbare strook')">
         <transition name="fade" mode="in-out">
             <HeroHome v-if="page == 'Home'" :videos="latestVideos" />
             <HeroGeneral v-else-if="page != 'Video'" />
         </transition>
-    </section>
+    </div>
 </template>
 
 <script>
@@ -36,7 +36,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-    #hero {
+    #heroInnerWrapper {
         position: relative;
         height: var(--heroHeight);
         animation: fade .6s;

--- a/src/components/ShareModal.vue
+++ b/src/components/ShareModal.vue
@@ -1,12 +1,12 @@
 <template>
-    <div id="shareLightBox" @click.self="$emit('close')" aria-label="Deelvenster" aria-role="none">
-        <div id="slbContent">
+    <div id="shareModal" @click.self="$emit('close')" aria-label="Deelvenster" aria-role="none">
+        <div id="smContent">
             <h3>Delen</h3>
-            <button id="slbCloseBtn" class="icon" @click.stop="$emit('close')" aria-label="Deelvenster sluiten"><fa icon="times" /></button>
-            <label id="slbLinkLabel" for="slbPath">Via URL:</label>
-            <div id="slbShareLink" @click="selectSlbLink" role="none">
-                <input id="slbPath" ref="slbPath" :value="url" readonly aria-label="URL naar video">
-                <button id="slbCopy" class="icon" @click.stop="copySlbLink" aria-label="URL naar video kopiëren">Kopieer</button>
+            <button id="smCloseBtn" class="icon" @click.stop="$emit('close')" aria-label="Deelvenster sluiten"><fa icon="times" /></button>
+            <label id="smLinkLabel" for="smPath">Via URL:</label>
+            <div id="smShareLink" @click="selectSmLink" role="none">
+                <input id="smPath" ref="smPath" :value="url" readonly aria-label="URL naar video">
+                <button id="smCopy" class="icon" @click.stop="copySmLink" aria-label="URL naar video kopiëren">Kopieer</button>
             </div>
         </div>
     </div>
@@ -14,7 +14,7 @@
 
 <script>
 export default {
-    name: 'ShareLightBox',
+    name: 'ShareModal',
     props: {
         url: String,
     },
@@ -22,22 +22,22 @@ export default {
         'close'
     ],
     methods: {
-        selectSlbLink() {
-            if (this.$refs.slbPath.select) {
-                this.$refs.slbPath.select();
+        selectSmLink() {
+            if (this.$refs.smPath.select) {
+                this.$refs.smPath.select();
             } else {
-                this.$refs.slbPath.setSelectionRange(0, this.$refs.slbPath.value.length);
+                this.$refs.smPath.setSelectionRange(0, this.$refs.smPath.value.length);
             }
         },
-        copySlbLink() {
-            navigator.clipboard.writeText(this.$refs.slbPath.value);
+        copySmLink() {
+            navigator.clipboard.writeText(this.$refs.smPath.value);
         }
     }
 }
 </script>
 
 <style lang="scss" scoped>
-    #shareLightBox {
+    #shareModal {
         position: fixed;
         top: 0;
         right: 0;
@@ -46,7 +46,7 @@ export default {
         background-color: rgba(0, 0, 0, .8);
         z-index: 40;
     }
-    #slbContent {
+    #smContent {
         position: absolute;
         top: 50%;
         left: 50%;
@@ -64,14 +64,14 @@ export default {
         right: 20px;
         top: 20px;
     }
-    #slbLinkLabel {
+    #smLinkLabel {
         display: block;
         margin-left: 10px;
         margin-bottom: 10px;
         color: $textColorGray;
         z-index: 1;
     }
-    #slbShareLink {
+    #smShareLink {
         position: relative;
         display: block;
         box-sizing: border-box;
@@ -82,13 +82,13 @@ export default {
         border-radius: 4px;
         font-size: .8em;
     }
-    #slbPath {
+    #smPath {
         background: transparent;
         color: $textColorGray;
         border: none;
         &:active, &:focus { outline: none; }
     }
-    #slbCopy {
+    #smCopy {
         font-size: .9em;
         top: 50%;
         transform: translateY(-50%);

--- a/src/components/ShareModal.vue
+++ b/src/components/ShareModal.vue
@@ -1,26 +1,28 @@
 <template>
-    <div id="shareModal" @click.self="$emit('close')" aria-label="Deelvenster" aria-role="none">
+    <div id="shareModal" @click.self="$emit('close')" role="dialog" aria-labelledby="smTitle" aria-modal="true">
         <div id="smContent">
-            <h3>Delen</h3>
-            <button id="smCloseBtn" class="icon" @click.stop="$emit('close')" aria-label="Deelvenster sluiten"><fa icon="times" /></button>
+            <h3 id="smTitle">Delen</h3>
+            <button id="smCloseBtn" class="icon" ref="firstTab" @click.stop="$emit('close')" aria-label="Deelvenster sluiten"><fa icon="times" /></button>
             <label id="smLinkLabel" for="smPath">Via URL:</label>
             <div id="smShareLink" @click="selectSmLink" role="none">
                 <input id="smPath" ref="smPath" :value="url" readonly aria-label="URL naar video">
-                <button id="smCopy" class="icon" @click.stop="copySmLink" aria-label="URL naar video kopiëren">Kopieer</button>
+                <button id="smCopy" class="icon" ref="lastTab" @click.stop="copySmLink" aria-label="URL naar video kopiëren">Kopieer</button>
             </div>
         </div>
     </div>
 </template>
 
 <script>
+import useModal from '../composables/modal.js';
+
 export default {
     name: 'ShareModal',
-    props: {
-        url: String,
-    },
     emits: [
         'close'
     ],
+    props: {
+        url: String,
+    },
     methods: {
         selectSmLink() {
             if (this.$refs.smPath.select) {
@@ -32,6 +34,9 @@ export default {
         copySmLink() {
             navigator.clipboard.writeText(this.$refs.smPath.value);
         }
+    },
+    setup() {
+        useModal();
     }
 }
 </script>

--- a/src/components/home/instagram/InstagramFeed.vue
+++ b/src/components/home/instagram/InstagramFeed.vue
@@ -1,8 +1,10 @@
 <template>
     <section id="instagramFeed" v-if="instagramPosts" aria-labelledby="instagramFeedTitle">
-        <transition name="modalFade">
-            <InstagramPostModal v-if="isPostOpened" :instagramName="instagramName" :post="currentPost" @close="closeModal" @gotoPrev="modalGotoPrev" @gotoNext="modalGotoNext" />
-        </transition>
+        <teleport to="#modals">
+            <transition name="modalFade">
+                <InstagramPostModal v-if="isPostOpened" :instagramName="instagramName" :post="currentPost" @close="closeModal" @gotoPrev="modalGotoPrev" @gotoNext="modalGotoNext" />
+            </transition>
+        </teleport>
         <div id="instagramFeedContent" ref="instagramFeedContent">
             <div class="container">
                 <div id="instagramFeedMeta">

--- a/src/components/home/instagram/InstagramPostModal.vue
+++ b/src/components/home/instagram/InstagramPostModal.vue
@@ -1,24 +1,24 @@
 <template>
-    <div id="instagramPostModal" @click.self="$emit('close')" aria-label="Instagram post modaal" aria-role="none">
-        <button id="ipmCloseBtn" class="icon" @click.stop="$emit('close')" title="Dialoogvenster sluiten" aria-label="Dialoogvenster sluiten"><fa icon="times" /></button>
-        <button id="ipmPrevBtn" class="icon" @click.stop="prevPost" title="Vorige post" aria-label="Vorige post">
+    <div id="instagramPostModal" @click.self="$emit('close')" role="dialog" aria-label="Instagram post" aria-modal="true">
+        <transition name="fade">
+            <ShareModal v-if="isShareModalOpen" :url="getShareURL()" @close="() => { this.isShareModalOpen = false; setInputDisable(false); }" />
+        </transition>
+        <button id="ipmCloseBtn" class="icon" ref="firstTab" @click.stop="$emit('close')" title="Dialoogvenster sluiten"><fa icon="times" /></button>
+        <button id="ipmPrevBtn" class="icon" @click.stop="prevPost" title="Vorige post">
             <img src="../../../assets/arrow.svg" alt="pijl naar links">
         </button>
         <transition :name="isContentSlideLeft ? 'modalContentSlideLeft' : 'modalContentSlideRight'">
-            <InstagramPostModalContent :key="post" :post="post" :instagramName="instagramName" @share="this.isShareModalOpen = true" />
+            <InstagramPostModalContent :key="post" :post="post" :instagramName="instagramName" @share="() => { this.isShareModalOpen = true; setInputDisable(true); }" />
         </transition>
-        <button id="ipmNextBtn" class="icon" @click.stop="nextPost" title="Volgende post" aria-label="Volgende post">
+        <button id="ipmNextBtn" class="icon" ref="lastTab" @click.stop="nextPost" title="Volgende post">
             <img src="../../../assets/arrow.svg" alt="pijl naar rechts">
         </button>
-        <teleport to="#modals">
-            <transition name="fade">
-                <ShareModal v-if="isShareModalOpen" :url="getShareURL()" @close="this.isShareModalOpen = false" />
-            </transition>
-        </teleport>
     </div>
 </template>
 
 <script>
+import useModal from '../../../composables/modal.js'
+
 import InstagramPostModalContent from './InstagramPostModalContent.vue'
 import ShareModal from '../../ShareModal.vue'
 
@@ -55,6 +55,10 @@ export default {
         getShareURL() {
             return window.location.href;
         }
+    },
+    setup() {
+        const { setInputDisable } = useModal();
+        return { setInputDisable };
     },
     beforeMount() {
         document.body.style.touchAction = 'none';

--- a/src/components/home/instagram/InstagramPostModal.vue
+++ b/src/components/home/instagram/InstagramPostModal.vue
@@ -5,26 +5,28 @@
             <img src="../../../assets/arrow.svg" alt="pijl naar links">
         </button>
         <transition :name="isContentSlideLeft ? 'modalContentSlideLeft' : 'modalContentSlideRight'">
-            <InstagramPostModalContent :key="post" :post="post" :instagramName="instagramName" @share="this.isShareLightboxOpen = true" />
+            <InstagramPostModalContent :key="post" :post="post" :instagramName="instagramName" @share="this.isShareModalOpen = true" />
         </transition>
         <button id="ipmNextBtn" class="icon" @click.stop="nextPost" title="Volgende post" aria-label="Volgende post">
             <img src="../../../assets/arrow.svg" alt="pijl naar rechts">
         </button>
-        <transition name="fade">
-            <ShareLightBox v-if="isShareLightboxOpen" :url="getShareURL()" @close="this.isShareLightboxOpen = false" />
-        </transition>
+        <teleport to="#modals">
+            <transition name="fade">
+                <ShareModal v-if="isShareModalOpen" :url="getShareURL()" @close="this.isShareModalOpen = false" />
+            </transition>
+        </teleport>
     </div>
 </template>
 
 <script>
 import InstagramPostModalContent from './InstagramPostModalContent.vue'
-import ShareLightBox from '../../ShareLightBox.vue'
+import ShareModal from '../../ShareModal.vue'
 
 export default {
     name: 'InstagramPostModal',
     components: {
         InstagramPostModalContent,
-        ShareLightBox
+        ShareModal
     },
     emits: [
         'close',
@@ -38,7 +40,7 @@ export default {
     data() {
         return {
             isContentSlideLeft: false,
-            isShareLightboxOpen: false
+            isShareModalOpen: false
         }
     },
     methods: {
@@ -111,7 +113,7 @@ export default {
         right: 50px;
         img { transform: rotate(180deg); }
     }
-    #shareLightBox {
+    #shareModal {
         &.fade-enter-from {
             opacity: 0;
         }

--- a/src/components/home/instagram/InstagramPostModalContent.vue
+++ b/src/components/home/instagram/InstagramPostModalContent.vue
@@ -25,8 +25,8 @@
             <div id="ipmBottomInfo">
                 <span id="ipmDate">{{post.date}}</span>
                 <div id="ipmMetaButtons">
-                    <button id="ipmShare" class="icon" @click="$emit('share')" title="Post delen" aria-label="Post delen"><fa icon="share-alt" /></button>
-                    <a id="ipmOpenLink" class="icon" :href="post.permalink" target="_blank" title="Open post op Instagram" aria-label="Open post op Instagram"><fa icon="external-link-alt" /></a>
+                    <button id="ipmShare" class="icon" @click="$emit('share')" title="Post delen"><fa icon="share-alt" /></button>
+                    <a id="ipmOpenLink" class="icon" :href="post.permalink" target="_blank" title="Open post op Instagram"><fa icon="external-link-alt" /></a>
                 </div>
             </div>
         </div>
@@ -43,6 +43,7 @@ export default {
         InstagramVideo,
         InstagramCarousel
     },
+    emits: [ 'share' ],
     props: {
         post: Object,
         instagramName: String

--- a/src/components/video/EndScreen.vue
+++ b/src/components/video/EndScreen.vue
@@ -1,24 +1,24 @@
 <template>
     <div id="endScreen" :class="{onVideoPage: isOnVideoPage}">
         <div id="autoPlayScreen" v-if="isAutoplay && !isAutoplayCancelled">
-            <button id="apCloseButton" class="icon" @click="cancelAutoplay" title="Autoplay annuleren" aria-label="Autoplay annuleren" tabindex="4"><fa icon="times" /></button>
+            <button id="apCloseButton" class="icon" @click="cancelAutoplay" title="Autoplay annuleren"><fa icon="times" /></button>
             <div id="apTimerBar">
                 <div id="apTimerProgress"></div>
             </div>
             <div id="apMainContent">
                 <h3 id="apTimerSub">Over {{autoplayCountdown}} seconden...</h3>
-                <VideoPreview :video="videos.values[recommendedVideoIds[0]]" :isPlaying="false" tabindex="4" />
+                <VideoPreview :video="videos.values[recommendedVideoIds[0]]" :isPlaying="false" />
                 <div id="apOptions">
-                    <button id="apCancel" class="btn" @click="cancelAutoplay" aria-label="Autoplay annuleren" tabindex="4">Annuleren</button>
-                    <button id="apContinue" class="btn" @click="continueAutoplay" aria-label="Autoplay verderzetten" tabindex="4">Afspelen</button>
+                    <button id="apCancel" class="btn" @click="cancelAutoplay" aria-label="Autoplay annuleren">Annuleren</button>
+                    <button id="apContinue" class="btn" @click="continueAutoplay" aria-label="Autoplay verderzetten">Afspelen</button>
                 </div>
             </div>
         </div>
         <div id="recommendedScreen">
             <h3 id="rsTitle">Misschien kijkt u ook naar...</h3>
-            <ul id="rsList" aria-label="Suggesties" tabindex="4">
+            <ul id="rsList" aria-label="Suggesties">
                 <li v-for="videoId of ( !isAutoplay || isAutoplayCancelled ? recommendedVideoIds: recommendedVideoIds.slice(1) )" :key="videoId">
-                    <VideoPreview :video="videos.values[videoId]" :isPlaying="false" tabindex="4" />
+                    <VideoPreview :video="videos.values[videoId]" :isPlaying="false" />
                 </li>
             </ul>
         </div>

--- a/src/components/video/MiniPlayer.vue
+++ b/src/components/video/MiniPlayer.vue
@@ -1,6 +1,7 @@
 <template>
     <div id="miniplayerInnerWrapper" :class="{ onVideoPage: isOnVideoPage, playlistOpen: isPlaylistOpen }">
         <VideoPlayer :video="playerVideo" :playerPlaylistInfo="playerPlaylistInfo" :videos="videos" :recommendedVideoIds="recommendedVideoIds" :isAutoplay="isAutoplay" :isOnVideoPage="isOnVideoPage" @setCurrentVideoId="videoId => $emit('setCurrentVideoId', videoId)" @close="$emit('close')" />
+        <div id="miniplayerTimelineWrapper"><!-- De tijdlijn van de video wordt naar hier geteleporteerd wanneer de minispeler actief is --></div>
         <div id="miniplayerTitle">
             <h2>{{playerVideo.title}}</h2>
             <button v-if="playerPlaylistInfo.playlistId != ''" id="expandPlaylist" class="icon" :title="isPlaylistOpen ? 'Afspeellijst verbergen' : 'Afspeellijst tonen'" @click="isPlaylistOpen = !isPlaylistOpen"></button>

--- a/src/components/video/MiniPlayer.vue
+++ b/src/components/video/MiniPlayer.vue
@@ -1,5 +1,5 @@
 <template>
-    <div id="miniplayer" :class="{ onVideoPage: isOnVideoPage, playlistOpen: isPlaylistOpen }">
+    <div id="miniplayerInnerWrapper" :class="{ onVideoPage: isOnVideoPage, playlistOpen: isPlaylistOpen }">
         <VideoPlayer :video="playerVideo" :playerPlaylistInfo="playerPlaylistInfo" :videos="videos" :recommendedVideoIds="recommendedVideoIds" :isAutoplay="isAutoplay" :isOnVideoPage="isOnVideoPage" @setCurrentVideoId="videoId => $emit('setCurrentVideoId', videoId)" @close="$emit('close')" />
         <div id="miniplayerTitle">
             <h2>{{playerVideo.title}}</h2>
@@ -51,7 +51,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-    #miniplayer {
+    #miniplayerInnerWrapper {
         display: flex;
         flex-direction: column;
         position: fixed;
@@ -132,7 +132,7 @@ export default {
             background-color: rgba(150, 150, 150, .3);
         }
     }
-    #miniplayer.playlistOpen {
+    #miniplayerInnerWrapper.playlistOpen {
         #expandPlaylist::before {
             transform: translateY(calc(-50% + 2px)) translateX(-50%) rotate(-135deg);
         }
@@ -142,7 +142,7 @@ export default {
     }
 
     @media screen and (max-width: 440px) {
-        #miniplayer:not(.onVideoPage) {
+        #miniplayerInnerWrapper:not(.onVideoPage) {
             width: calc(100% - 24px);
         }
     }

--- a/src/components/video/MountedTeleport.vue
+++ b/src/components/video/MountedTeleport.vue
@@ -10,17 +10,26 @@ import { ref } from 'vue';
 export default {
     name: "MountedTeleport",
     props: {
+        // CSS selector voor het element waarnaar er wordt geteleporteerd
         to: {
             type: String,
             default: 'body'
         },
+        // Als disabled==false, dan zal het element niet worden geteleporteerd (ongeacht als wel/niet op juiste pagina)
         disabled: {
             type: Boolean,
             default: false
         },
+        // Paginanaam waarop het element (niet) moet komen
         pageName: {
             type: String,
             default: ''
+        },
+        // Als inverted==false, dan wordt het element enkel geteleporteerd als op pagina 'pageName'.
+        // Als inverted==true, dan wordt het element geteleporteerd als niet op pagina 'pageName'.
+        inverted: {
+            type: Boolean,
+            default: false
         }
     },
     data() {
@@ -32,7 +41,7 @@ export default {
     methods: {
         reloadTarget(route) {
             this.$nextTick(() => {
-                if (route.name == this.pageName) {
+                if ((route.name == this.pageName) != this.inverted) { // XOR(route.name == this.pageName, this.inverted)
                     this.isOnPage = true;
                     const el = document.querySelector(this.to);
                     if (el) this.target = el;

--- a/src/components/video/Playlist.vue
+++ b/src/components/video/Playlist.vue
@@ -1,7 +1,7 @@
 <template>
     <div id="playlist" v-if="playerPlaylist" aria-label="Afspeellijst">
         <div id="playlistHeader">
-            <h3>{{playerPlaylist.title}}</h3>
+            <component :is="isOnVideoPage ? 'h2' : 'h3'" id="playlistTitle">{{playerPlaylist.title}}</component>
             <div id="playlistControls">
                 <ul :aria-label="`Opties voor afspeellijst '${playerPlaylist.title}'`">
                     <li>
@@ -162,7 +162,7 @@ export default {
         padding-bottom: 10px;
         border-bottom: 1px solid $sectionBorderColor;
 
-        h3 {
+        #playlistTitle {
             display: inline-block;
             flex: 1;
             color: $headingColor;

--- a/src/components/video/VideoPlayer.vue
+++ b/src/components/video/VideoPlayer.vue
@@ -1164,7 +1164,7 @@ export default {
     @media screen and (max-width: 410px) {
         #videoPlayerWrapper.videoPage #videoPlayer #playerContainer {
             #timeline {
-                transform: translateY(-450%);
+                bottom: 20px;
             }
             .overlay .controls {
                 button.icon, #time span {

--- a/src/components/video/VideoPlayer.vue
+++ b/src/components/video/VideoPlayer.vue
@@ -2,15 +2,15 @@
     <div id="videoPlayerWrapper" ref="videoPlayerWrapper" :class="{videoPage: isOnVideoPage}">
         <div class="dragOverlay" v-if="draggingType != 0" @mousemove="drag" @mouseup="endDrag" />
         <div id="videoPlayer" v-if="video" @dragstart="preventDefault" aria-label="Videospeler">
-            <div id="playerContainer" ref="playerContainer" :class="{dragging: draggingType != 0, paused: isPaused, buffering: isBuffering, pbrModalOpen: isPlaybackRateModalOpen, idle: isIdle}" role="widget" :aria-roledescription="`Video met titel '${this.video.title}'`" :tabindex="isOnVideoPage ? 5 : 2">
+            <div id="playerContainer" ref="playerContainer" :class="{dragging: draggingType != 0, paused: isPaused, buffering: isBuffering, pbrModalOpen: isPlaybackRateModalOpen, idle: isIdle}" role="widget" :aria-roledescription="`Video met titel '${this.video.title}'`" tabindex="0">
                 <div id="playerContent" v-show="errorVal == 0" @mouseenter="resetIdleTimer" @mouseleave="clearIdleTimer">
                     <div id="video" ref="video" v-on="{ click: isOnVideoPage ? null : () => pausePlay(false)}">
                         <YouTube id="youtube" ref="youtube" v-show="errorVal == 0" :vars="playerVars" :width="videoWidth" :height="videoHeight" src="" @ready="loadVideo" @state-change="stateChange" @error="error" draggable="false" />
                         <div class="overlay">
-                            <button class="close icon" tabindex="3" aria-label="Afsluiten" @click.stop="close"><fa icon="times" /></button>
-                            <button class="expand icon" tabindex="2" aria-label="Vergroten" @click.stop="expand"><fa icon="external-link-alt" rotation="270" /></button>
+                            <button class="close icon" aria-label="Afsluiten" @click.stop="close"><fa icon="times" /></button>
+                            <button class="expand icon" aria-label="Vergroten" @click.stop="expand"><fa icon="external-link-alt" rotation="270" /></button>
                             <div class="controls">
-                                <button class="pausePlay icon" tabindex="6" :aria-label="currentPlayerState == 0 ? 'Herhalen' : (isPaused ? 'Afspelen' : 'Pauzeren')" @click.stop="currentPlayerState == 0 ? replay() : pausePlay(false)"><fa :icon="currentPlayerState == 0 ? 'rotate-left' : (isPaused ? 'play' : 'pause')" /></button>
+                                <button class="pausePlay icon" :aria-label="currentPlayerState == 0 ? 'Herhalen' : (isPaused ? 'Afspelen' : 'Pauzeren')" @click.stop="currentPlayerState == 0 ? replay() : pausePlay(false)"><fa :icon="currentPlayerState == 0 ? 'rotate-left' : (isPaused ? 'play' : 'pause')" /></button>
                                 <button class="volume icon" tabindex="-1" aria-label="Volume" @mouseover="this.isVolumeWrapperOpen = true"><fa :icon="this.isMuted ? 'volume-mute' : (this.volume == 0 ? 'volume-off' : (this.volume < 70 ? 'volume-down' : 'volume-up'))" /></button>
                                 <div id="time" v-if="$refs.youtube">
                                     <span id="currentTime">{{videoTimeSecFormatted}}</span>
@@ -18,10 +18,10 @@
                                     <span id="maxTime">{{video.durationFormatted}}</span>
                                 </div>
                                 <div class="floatRight" v-if="isOnVideoPage">
-                                    <button class="youtubeBtn icon" tabindex="9" aria-label="Op YouTube bekijken" @click.stop="watchOnYoutube"><fa :icon="['fab', 'youtube']" /></button>
-                                    <button class="playbackRate icon" tabindex="9" ref="playbackRateBtn" aria-label="Snelheid" @click.stop="togglePlaybackRateModal"><fa icon="tachometer-alt" /></button>
-                                    <button class="miniplayer icon" tabindex="11" aria-label="Minimalizeren" @click="gotoVideos"><fa icon="external-link-alt" rotation="90" /></button>
-                                    <button class="fullscreen icon" tabindex="11" aria-label="Volledig scherm" @click="toggleFullscreenMode"><fa :icon="this.isInFullscreenMode ? 'compress' : 'expand'" /></button>
+                                    <button class="youtubeBtn icon" aria-label="Op YouTube bekijken" @click.stop="watchOnYoutube"><fa :icon="['fab', 'youtube']" /></button>
+                                    <button class="playbackRate icon" ref="playbackRateBtn" aria-label="Snelheid" @click.stop="togglePlaybackRateModal"><fa icon="tachometer-alt" /></button>
+                                    <button class="miniplayer icon" aria-label="Minimalizeren" @click="gotoVideos"><fa icon="external-link-alt" rotation="90" /></button>
+                                    <button class="fullscreen icon" aria-label="Volledig scherm" @click="toggleFullscreenMode"><fa :icon="this.isInFullscreenMode ? 'compress' : 'expand'" /></button>
                                 </div>
                             </div>
                         </div>
@@ -32,19 +32,19 @@
                         </div>
                     </div>
                     <div id="volumeSliderOuterWrapper" :class="{open: isVolumeWrapperOpen}" ref="volumeSliderOuterWrapper" @mouseleave="mouseLeaveVolumeSliderWrapper">
-                        <div id="volumeSliderInnerWrapper" tabindex="8" @mousedown.left="startDragVolumeSlider" @keydown="sliderVolumeKeydown" role="slider" aria-label="volume" aria-valuemin="0" aria-valuemax="100" :aria-valuenow="volume" :aria-valuetext="`${this.volume}%`">
+                        <div id="volumeSliderInnerWrapper" @mousedown.left="startDragVolumeSlider" @keydown="sliderVolumeKeydown" role="slider" aria-label="volume" aria-valuemin="0" aria-valuemax="100" :aria-valuenow="volume" :aria-valuetext="`${this.volume}%`">
                             <div id="volumeSlider" ref="volumeSlider">
                                 <div id="volumeSliderLevel" :style="{height: this.isMuted ? '0' : this.volume + '%'}" />
                             </div>
                         </div>
-                        <button class="muteAudio icon" tabindex="7" :aria-label="isMuted ? 'Geluid inschakelen' : 'Geluid uitschakelen'" @click="toggleMute"></button>
+                        <button class="muteAudio icon" :aria-label="isMuted ? 'Geluid inschakelen' : 'Geluid uitschakelen'" @click="toggleMute"></button>
                     </div>
                     <div id="playbackRateModal" ref="playbackRateModal" v-show="isPlaybackRateModalOpen" @keydown.esc.stop="togglePlaybackRateModal">
                         <ul role="listbox" aria-label="Snelheid kiezen">
-                            <li :key="option" v-for="option in availablePlaybackRates" :class="{selected: this.playbackRate == option}" tabindex="10" @click="setPlaybackRate(option)" @keydown.enter.space.prevent="setPlaybackRate(option)" role="option" :aria-label="option == 1 ? 'originele snelheid' : `${option*100}% van originele snelheid`" :aria-selected="this.playbackRate == option">{{option}}</li>
+                            <li :key="option" v-for="option in availablePlaybackRates" :class="{selected: this.playbackRate == option}" @click="setPlaybackRate(option)" @keydown.enter.space.prevent="setPlaybackRate(option)" role="option" :aria-label="option == 1 ? 'originele snelheid' : `${option*100}% van originele snelheid`" :aria-selected="this.playbackRate == option">{{option}}</li>
                         </ul>
                     </div>
-                    <div id="timeline" :tabindex="this.isOnVideoPage ? 5 : 12" :class="{dragging: this.draggingType == 1}" ref="timeline" @mousemove="calculateHoveredTimelineTime" @mousedown.left="startDragTimeline" @keydown="sliderTimelineKeydown" role="slider" aria-label="tijdlijn" aria-valuemin="0" :aria-valuemax="video.durationSec" :aria-valuenow="videoTimeSec" :aria-valuetext="timelineAriaText">
+                    <div id="timeline" tabindex="0" :class="{dragging: this.draggingType == 1}" ref="timeline" @mousemove="calculateHoveredTimelineTime" @mousedown.left="startDragTimeline" @keydown="sliderTimelineKeydown" role="slider" aria-label="tijdlijn" aria-valuemin="0" :aria-valuemax="video.durationSec" :aria-valuenow="videoTimeSec" :aria-valuetext="timelineAriaText">
                         <div id="tlBackground"></div>
                         <div id="tlBuffered" :style="{width: this.videoLoadedFrac * 100 + '%'}"></div>
                         <div id="tlProgress" :style="{width: this.videoTimeSec / this.video.durationSec * 100 + '%'}"></div>

--- a/src/components/video/VideoPlayer.vue
+++ b/src/components/video/VideoPlayer.vue
@@ -584,7 +584,33 @@ export default {
                 height: var(--pcHeight) !important;
                 pointer-events: auto;
 
-                #playerContent { height: 100%; }    
+                #playerContent {
+                    height: 100%;
+
+                    .overlay {
+                        &::before {
+                            content: '';
+                            position: absolute;
+                            bottom: 0;
+                            left: 0;
+                            height: 100px;
+                            width: 100%;
+                            pointer-events: none;
+                            @include scrimGradient(rgb(0, 0, 0), 'to top');
+                        }
+                        &::after {
+                            content: '';
+                            display: block;
+                            position: absolute;
+                            bottom: 0;
+                            left: 0;
+                            width: 100%;
+                            height: 50px;
+                            backdrop-filter: blur(1px);
+                            z-index: -1;
+                        }
+                    }
+                }    
                 #video {
                     border-radius: 4px;
                     &::after { display: none; }
@@ -603,31 +629,7 @@ export default {
 
                     #errorContent { transform: translateY(calc(-50% - 30px)); }
                 }
-                .overlay {
-                    &::before {
-                        content: '';
-                        position: absolute;
-                        bottom: 0;
-                        left: 0;
-                        height: 100px;
-                        width: 100%;
-                        pointer-events: none;
-                        @include scrimGradient(rgb(0, 0, 0), 'to top');
-                    }
-                    &::after {
-                        content: '';
-                        display: block;
-                        position: absolute;
-                        bottom: 0;
-                        left: 0;
-                        width: 100%;
-                        height: 50px;
-                        backdrop-filter: blur(1px);
-                        z-index: -1;
-                    }
-
-                    & > button { display: none; }
-                }
+                .overlay > button { display: none; }
             }
             #timeline {
                 width: calc(100% - 20px);

--- a/src/components/video/VideoPlayer.vue
+++ b/src/components/video/VideoPlayer.vue
@@ -57,8 +57,8 @@
                 <EndScreen v-if="currentPlayerState == 0" :videos="videos" :recommendedVideoIds="recommendedVideoIds" :isAutoplay="isAutoplay" :isOnVideoPage="isOnVideoPage" @setCurrentVideoId="videoId => $emit('setCurrentVideoId', videoId)" />
                 <div id="error" v-if="errorVal != 0">
                     <div class="overlay">
-                        <button class="close icon" aria-label="Afsluiten" @click.stop="close"><fa icon="times" /></button>
                         <button class="expand icon" aria-label="Vergroten" @click.stop="expand"><fa icon="external-link-alt" rotation="270" /></button>
+                        <button class="close icon" aria-label="Afsluiten" @click.stop="close"><fa icon="times" /></button>
                     </div>
                     <div id="errorContent">
                         <h2>Het lijkt erop dat de video niet kan geladen worden!</h2>
@@ -756,7 +756,7 @@ export default {
         border-top-left-radius: 4px;
         border-top-right-radius: 4px;
 
-        &:hover, &.dragging, &.hoveringTimeline, #playerContent:focus-within {
+        &:hover, &.dragging, &.hoveringTimeline, #playerContent:focus-within, #error:focus-within {
             #video::after, .overlay { opacity: 1; }
         }
         &.paused #pauseIcon {

--- a/src/components/videos/VideoGallery.vue
+++ b/src/components/videos/VideoGallery.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="videoGallery" ref="videoGallery">
-        <h3>{{title}}</h3>
+        <component :is="`h${headingLevel}`" class="videoGalleryTitle">{{title}}</component>
         <ul class="videoContent" :aria-label="title">
             <li class="videoItem" :key="videoId" v-for="videoId in videoIds.slice(0, shownVideoCount)">
                 <VideoPreview class="videoPreview" :video="videos.values[videoId]" :isPlaying="playerVideo ? videos.values[videoId].id == playerVideo.id : false" />
@@ -22,6 +22,10 @@ export default {
     },
     props: {
         title: String,
+        headingLevel: {
+            type: String,
+            default: '3'
+        },
         videos: Object,
         videoIds: Array,
         playerVideo: Object,
@@ -51,11 +55,12 @@ export default {
         border: 1px solid $sectionBorderColor;
         border-radius: 4px;
 
-        h3 {
+        .videoGalleryTitle {
             position: relative;
             color: $headingColor;
             margin: 10px 0;
             text-align: center;
+            font-size: 1.1em;
         }
     }
     .videoContent {

--- a/src/composables/event.js
+++ b/src/composables/event.js
@@ -1,0 +1,6 @@
+import { onMounted, onUnmounted } from 'vue'
+
+export function useGlobalEventListener(event, callback) {
+    onMounted( () => document.addEventListener(event, callback) );
+    onUnmounted( () => document.removeEventListener(event, callback) );
+}

--- a/src/composables/modal.js
+++ b/src/composables/modal.js
@@ -1,0 +1,40 @@
+import { ref, onMounted, onUnmounted, getCurrentInstance } from 'vue'
+import { useGlobalEventListener } from './event';
+
+export default function useModal() {
+    const instance = getCurrentInstance();
+    const isInputDisabled = ref(false);
+
+    function setInputDisable(bool) {
+        isInputDisabled.value = bool;
+    }
+
+    const prevFocus = ref(null);
+    onMounted(() => {
+        prevFocus.value = document.activeElement;
+        instance.refs.firstTab.focus();
+    });
+    onUnmounted(() => {
+        prevFocus.value.focus();
+    });
+
+    useGlobalEventListener('keydown', e => {
+        if (!isInputDisabled.value) {
+            if (e.key == 'Tab') {
+                // Zorg voor focus trapping als dialoogvenster open
+                if (document.activeElement == instance.refs.firstTab && e.shiftKey) {
+                    instance.refs.lastTab.focus();
+                    e.preventDefault();
+                } else if (document.activeElement == instance.refs.lastTab && !e.shiftKey) {
+                    instance.refs.firstTab.focus();
+                    e.preventDefault();
+                }
+            } else if (e.key == 'Escape') {
+                // Sluit het dialoogvenster als de gebruiker 'escape' indrukt
+                instance.emit('close');
+            }
+        }
+    });
+
+    return { setInputDisable };
+}

--- a/src/views/Video.vue
+++ b/src/views/Video.vue
@@ -10,10 +10,10 @@
                 <div id="playerBackground" />
                 <div id="videoMeta">
                     <div id="videoHeading">
-                        <h2 id="videoTitle">
+                        <h1 id="videoTitle">
                             {{playerVideo.title}}
                             <button id="shareBtn" class="icon" @click="isShareModalOpen = true" aria-label="Delen" title="Delen"><fa icon="share-alt" /></button>
-                        </h2>                        
+                        </h1>                        
                     </div>
                     <p id="videoGeneralMeta">
                         <span id="videoMetaViews">{{playerVideo.views}} weergaven</span>
@@ -25,7 +25,7 @@
             <aside id="sidebar" v-if="recommendedVideoIds">
                 <div id="playlistContainer"><!-- Afspeellijst wordt aan dit element gekoppeld --></div>
                 <AutoPlay :isAutoplay="isAutoplay" @setAutoplay="isAutoplay => $emit('setAutoplay', isAutoplay)" />
-                <VideoGallery title="Enkele suggesties" :videos="videos" :videoIds="recommendedVideoIds" :playerVideo="playerVideo" :shownVideoCount="shownRecommendedVideos" @increaseShownVideoCount="shownRecommendedVideos += 3" :isLoadedByRequest="false" />
+                <VideoGallery title="Enkele suggesties" headingLevel="2" :videos="videos" :videoIds="recommendedVideoIds" :playerVideo="playerVideo" :shownVideoCount="shownRecommendedVideos" @increaseShownVideoCount="shownRecommendedVideos += 3" :isLoadedByRequest="false" />
             </aside>
         </div>
     </div>
@@ -134,7 +134,7 @@ export default {
         width: #{$videoPageSidebarWidthFrac * 100vw};
         margin-bottom: 50px;
 
-        h2 {
+        h1 {
             font-size: 1.2em;
             margin-bottom: 10px;
             color: $headingColor;

--- a/src/views/Video.vue
+++ b/src/views/Video.vue
@@ -1,8 +1,10 @@
 <template>
     <div id="viewVideo" class="view" ref="video">
-        <transition name="fade">
-            <ShareLightBox v-if="isShareLightBoxOpen" :url="getShareURL()" @close="isShareLightBoxOpen = false" />
-        </transition>
+        <teleport to="#modals">
+            <transition name="fade">
+                <ShareModal v-if="isShareModalOpen" :url="getShareURL()" @close="isShareModalOpen = false" />
+            </transition>
+        </teleport>
         <div class="container" v-if="playerVideo">
             <section id="video">
                 <div id="playerBackground" />
@@ -10,7 +12,7 @@
                     <div id="videoHeading">
                         <h2 id="videoTitle">
                             {{playerVideo.title}}
-                            <button id="shareBtn" class="icon" @click="isShareLightBoxOpen = true" aria-label="Delen" title="Delen"><fa icon="share-alt" /></button>
+                            <button id="shareBtn" class="icon" @click="isShareModalOpen = true" aria-label="Delen" title="Delen"><fa icon="share-alt" /></button>
                         </h2>                        
                     </div>
                     <p id="videoGeneralMeta">
@@ -32,7 +34,7 @@
 <script>
 import AutoPlay from '../components/video/AutoPlay.vue'
 import VideoGallery from '../components/videos/VideoGallery.vue'
-import ShareLightBox from '../components/ShareLightBox.vue'
+import ShareModal from '../components/ShareModal.vue'
 
 export default {
     name: 'Video',
@@ -45,14 +47,14 @@ export default {
     },
     components: {
         VideoGallery,
-        ShareLightBox,
+        ShareModal,
         AutoPlay
     },
     data() {
         return {
             videoId: this.$route.params.videoId,
             shownRecommendedVideos: 4,
-            isShareLightBoxOpen: false
+            isShareModalOpen: false
         }
     },
     methods: {

--- a/update/postcompile.py
+++ b/update/postcompile.py
@@ -6,7 +6,7 @@ import glob
 def main():
     # Kopieer gegenereerde head tags
     with open(os.path.abspath('dist/index.html'), 'r') as f:
-        html_head_tags = re.findall(r"\.ico\"\>(.*?)\<\/head\>", f.read())[0]
+        html_head_tags = re.findall(r"\<\/script\>(.*?)\<\/head\>", f.read())[0]
     
     # Sla op in ander bestand
     f = open(os.path.abspath('dist/htmlHeadTags.html'), "w+")

--- a/update/static_page_preset.html
+++ b/update/static_page_preset.html
@@ -27,6 +27,24 @@
   <link rel="icon" href="/favicon.ico">
   <!-- Default styles -->
   $styling
+  <!-- Preload script -->
+  <script type="text/javascript">
+    // Maak laadscherm
+    let $loadingScreen = document.createElement('div');
+    $loadingScreen.id = 'loadingScreen';
+    $loadingScreen.innerText = "Laden...";
+    setTimeout(() => {
+      // Verstop noscript wrapper
+      document.getElementById('noscriptWrapper').style.display = 'none';
+      // Plak laadscherm aan body
+      document.body.prepend($loadingScreen);
+    }, 10);
+
+    // Verstop alle preview-elementen
+    let $style = document.createElement('style');
+    $style.innerText = ".preview { display: none; } #loadingScreen { color: white; }"
+    document.head.appendChild($style);
+  </script>
   <!-- Content scripts and styles -->
   $headTags
 </head>

--- a/update/static_page_preset.html
+++ b/update/static_page_preset.html
@@ -31,47 +31,62 @@
   $headTags
 </head>
 <body style="background-color: black; overflow-x: hidden;">
+  <div id="noscriptWrapper">
     <noscript>
       <iframe src="/enablejs.html" frameborder="0" style="width: 100%; height: 100vh"></iframe>
-      <div id="preview">
-        <div id="previewTitle">
-          <h1>$title</h1>
-        </div>
-        <div id="previewHeader">
-          $headerHTML
-        </div>
-        <div id="previewContent">
-          $contentHTML
-        </div>
-      </div>
-      <style>
-        body {
-          margin: 0;
-          padding: 0;
-          min-height: 100vh;
-        }
-        #preview h2 {
-          margin: 20px 10px;
-          font-size: 1.3em;
-          color: lightblue;
-        }
-        #preview h1 {
-          margin: 30px 0;
-          font-size: 2em;
-          text-align: center;
-          color: lightblue;
-        }
-        #preview li {
-          margin-left: 50px;
-        }
-        #preview li, #preview p {
-          color: white;
-        }
-        #preview a {
-          display: inline-block;
-        }
-      </style>
     </noscript>
-    <div id="app"></div>
+  </div>
+
+  <div id="modals" class="preview"></div>
+
+  <header id="header" class="preview">
+    $headerHTML
+  </header>
+
+  <div id="miniplayer"></div>
+
+  <main>
+    <section id="hero" class="preview">
+      <h1>$title</h1>
+    </section>
+    <div id="viewContent" class="preview">
+      $contentHTML
+    </div>
+  </main>
+
+  <footer id="footer" class="preview"></footer>
+
+  <div id="app"></div>
+
+  <style>
+    body {
+      margin: 0;
+      padding: 0;
+      min-height: 100vh;
+    }
+    #noscriptWrapper {
+      min-height: 100vh;
+    }
+    .preview h2 {
+      margin: 20px 10px;
+      font-size: 1.3em;
+      color: lightblue;
+    }
+    .preview h1 {
+      margin: 30px 0;
+      font-size: 2em;
+      text-align: center;
+      color: lightblue;
+    }
+    .preview li {
+      margin-left: 50px;
+    }
+    .preview li, .preview p {
+      color: white;
+    }
+    .preview a {
+      display: inline-block;
+    }
+  </style>
 </body>
 </html>


### PR DESCRIPTION
Deze pull request zorgt voor vele verbeteringen op het vlak van accessibiliteit en SEO:
- Een deel van de inhoud van de pagina is nu beschikbaar zonder Javascript onder de vorm van "preview-elementen". Deze informatie was vooraf niet beschikbaar voor gebruikers die Javascript uit hadden staan, maar dit toch niet aangaven (wanneer de `<noscript>`-inhoud niet werd niet getoond en Javascript toch aan). Ik hoop hiermee onder andere ook de SEO bij te werken.

- Wanneer de site een gebruiker met Javascript detecteert, laat het meteen de preview-elementen verdwijnen en komt er een (eenvoudig) laadscherm. Dit laatste geeft de feedback aan de gebruiker dat de site daadwerkelijk aan het laden is. Het laadscherm kan later nog mooier gemaakt worden, maar dit is opzich geen prioriteit.

- Deze preview-elementen worden ook niet echt vernietigd wanneer de site wordt geactiveert met Javascript, maar worden eerder hergebruikt als wrapper voor de Vue-inhoud. Dit vermijdt duplicaten van semantische elementen zoals `<footer>` en `<main>` en houdt de site netjes voor screen readers en SEO-robots.

- Verder is zowat elke toepassing van het HTML-attribuut 'tabindex' weggewerkt aan de hand van Vue3-teleportatie en (S)CSS-trucjes. Dit bevordert de toegankelijkheid van de site enorm en maakt de HTML-opmaak iets minder chaotisch.

- Dialoogvensters zijn nu ook veel toegankelijker gemaakt met de tabtoets door een techniek genaamd 'focus trapping': je kan niet langer met de tabtoets alleen buiten een dialoogvenster navigeren. De focus net voor het openen van het venster wordt ook hersteld wanneer het opnieuw wordt gesloten.

- Daarnaast zijn de heading levels op de videopagina's gecorrigeerd.

- Ten slotte zijn er ook enkele (kleine) bugfixes gemaakt, waardoor de site net iets beter draait.